### PR TITLE
refactor: Add code formatting and remove hacks

### DIFF
--- a/checks.nix
+++ b/checks.nix
@@ -1,4 +1,5 @@
-{ pkgs, ... }: let
+{ pkgs, ... }:
+let
   lake = import ./lake.nix { inherit pkgs; };
   minimal-direct = pkgs.lean.buildLeanPackage {
     name = "Example";
@@ -13,7 +14,8 @@
     src = pkgs.lib.cleanSource ./templates/dependency;
     roots = [ "Example" ];
   };
-in {
+in
+{
   minimal-direct = minimal-direct.executable;
   minimal-manifest = minimal-manifest.executable;
   dependency-manifest = dependency-manifest.executable;

--- a/flake.lock
+++ b/flake.lock
@@ -49,7 +49,23 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -6,34 +6,37 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
   };
 
-  outputs = inputs @ {
-    self,
-    nixpkgs,
-    flake-parts,
-    ...
-  } : flake-parts.lib.mkFlake { inherit inputs; } {
-    flake = (import ./overlay.nix) // {
-      lake = import ./lake.nix;
-      templates = import ./templates;
-    };
-    systems = [
-      "x86_64-linux"
-      "x86_64-darwin"
-      "aarch64-linux"
-      "aarch64-darwin"
-    ];
-    perSystem = { system, pkgs, ... }: let
-      overlay = import ./overlay.nix;
-      pkgs = import nixpkgs {
-        inherit system;
-        overlays = [ (overlay.readToolchainFile ./templates/minimal/lean-toolchain) ];
+  outputs =
+    inputs @ { self
+    , nixpkgs
+    , flake-parts
+    , ...
+    }: flake-parts.lib.mkFlake { inherit inputs; } {
+      flake = (import ./overlay.nix) // {
+        lake = import ./lake.nix;
+        templates = import ./templates;
       };
-      checks = import ./checks.nix { inherit pkgs; };
-    in {
-      packages = {
-        inherit (pkgs.lean) leanshared lean leanc lean-all lake;
-      };
-      inherit checks;
+      systems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      perSystem = { system, pkgs, ... }:
+        let
+          overlay = import ./overlay.nix;
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ (overlay.readToolchainFile ./templates/minimal/lean-toolchain) ];
+          };
+          checks = import ./checks.nix { inherit pkgs; };
+        in
+        {
+          packages = {
+            inherit (pkgs.lean) leanshared lean leanc lean-all lake;
+          };
+          inherit checks;
+          formatter = pkgs.nixpkgs-fmt;
+        };
     };
-  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
     flake-parts.url = "github:hercules-ci/flake-parts";
+    systems.url = "github:nix-systems/default";
   };
 
   outputs =
@@ -12,16 +13,13 @@
     , flake-parts
     , ...
     }: flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = import inputs.systems;
+
       flake = (import ./overlay.nix) // {
         lake = import ./lake.nix;
         templates = import ./templates;
       };
-      systems = [
-        "x86_64-linux"
-        "x86_64-darwin"
-        "aarch64-linux"
-        "aarch64-darwin"
-      ];
+
       perSystem = { system, pkgs, ... }:
         let
           overlay = import ./overlay.nix;

--- a/lake.nix
+++ b/lake.nix
@@ -1,43 +1,52 @@
-{ pkgs }: let
+{ pkgs }:
+let
   capitalize = s:
     let
       first = pkgs.lib.toUpper (builtins.substring 0 1 s);
       rest = builtins.substring 1 (-1) s;
     in
-      first + rest;
-  importLakeManifest = manifestFile: let
+    first + rest;
+  importLakeManifest = manifestFile:
+    let
       manifest = pkgs.lib.importJSON manifestFile;
     in
-      pkgs.lib.warnIf (manifest.version != "1.1.0") ("Unknown version: " + manifest.version) manifest;
-  depToPackage = dep : let
-    src = pkgs.lib.cleanSource (builtins.fetchGit {
-      inherit (dep) url rev;
-      shallow = true;
-    });
-  in {
-    inherit src;
-    manifestFile = "${src}/${dep.manifestFile}";
-  };
+    pkgs.lib.warnIf (manifest.version != "1.1.0") ("Unknown version: " + manifest.version) manifest;
+  depToPackage = dep:
+    let
+      src = pkgs.lib.cleanSource (builtins.fetchGit {
+        inherit (dep) url rev;
+        shallow = true;
+      });
+    in
+    {
+      inherit src;
+      manifestFile = "${src}/${dep.manifestFile}";
+    };
   # Builds a Lean package by reading the manifest file.
-  mkPackage = {
+  mkPackage =
+    {
       # Path to the source
-      src,
-      # Path to the `lake-manifest.json` file
-      manifestFile ? "${src}/lake-manifest.json",
-      # Root module
-      roots ? null,
-      # Default dependencies
-      deps ? with pkgs.lean; [ Init Std Lean ],
-    } : let
-    manifest = importLakeManifest manifestFile;
-    # Build all dependencies using `buildLeanPackage`
-    manifestDeps = builtins.map (dep : mkPackage (depToPackage dep)) manifest.packages;
-  in pkgs.lean.buildLeanPackage {
-    inherit (manifest) name;
-    inherit src;
-    roots = if builtins.isNull roots then [ (capitalize manifest.name) ] else roots;
-    deps = deps ++ manifestDeps;
-  };
-in {
+      src
+    , # Path to the `lake-manifest.json` file
+      manifestFile ? "${src}/lake-manifest.json"
+    , # Root module
+      roots ? null
+    , # Default dependencies
+      deps ? with pkgs.lean; [ Init Std Lean ]
+    ,
+    }:
+    let
+      manifest = importLakeManifest manifestFile;
+      # Build all dependencies using `buildLeanPackage`
+      manifestDeps = builtins.map (dep: mkPackage (depToPackage dep)) manifest.packages;
+    in
+    pkgs.lean.buildLeanPackage {
+      inherit (manifest) name;
+      inherit src;
+      roots = if builtins.isNull roots then [ (capitalize manifest.name) ] else roots;
+      deps = deps ++ manifestDeps;
+    };
+in
+{
   inherit mkPackage;
 }

--- a/lib/packages.nix
+++ b/lib/packages.nix
@@ -20,7 +20,7 @@ let
     '';
   }).overrideAttrs (old: {
     # https://github.com/NixOS/nixpkgs/issues/119779
-    installPhase = builtins.replaceStrings ["use_response_file_by_default=1"] ["use_response_file_by_default=0"] old.installPhase;
+    installPhase = builtins.replaceStrings [ "use_response_file_by_default=1" ] [ "use_response_file_by_default=0" ] old.installPhase;
   });
   stdenv' = if stdenv.isLinux then useGoldLinker stdenv else stdenv;
   lean = callPackage bootstrap (args // {
@@ -28,10 +28,12 @@ let
     inherit src buildLeanPackage llvmPackages;
   });
   makeOverridableLeanPackage = f:
-    let newF = origArgs: f origArgs // {
-      overrideArgs = newArgs: makeOverridableLeanPackage f (origArgs // newArgs);
-    };
-    in lib.setFunctionArgs newF (lib.functionArgs f) // {
+    let
+      newF = origArgs: f origArgs // {
+        overrideArgs = newArgs: makeOverridableLeanPackage f (origArgs // newArgs);
+      };
+    in
+    lib.setFunctionArgs newF (lib.functionArgs f) // {
       override = args: makeOverridableLeanPackage (f.override args);
     };
   buildLeanPackage = makeOverridableLeanPackage (callPackage (import "${src}/nix/buildLeanPackage.nix") (args // {
@@ -39,7 +41,8 @@ let
     lean = lean.stage1;
     inherit (lean.stage1) leanc;
   }));
-in {
+in
+{
   inherit cc buildLeanPackage llvmPackages;
   nixpkgs = pkgs;
   ciShell = writeShellScriptBin "ciShell" ''

--- a/lib/packages.nix
+++ b/lib/packages.nix
@@ -1,32 +1,16 @@
-{ src, pkgs, bootstrap, llvmPackages, ... } @ args:
-with pkgs;
+args @{ bootstrap
+, callPackage
+, lib
+, llvmPackages
+, src
+}:
+
 let
-  llvmPackages = llvmPackages_15;
-  cc = (ccacheWrapper.override rec {
-    cc = llvmPackages.clang;
-    extraConfig = ''
-      export CCACHE_DIR=/nix/var/cache/ccache
-      export CCACHE_UMASK=007
-      export CCACHE_BASE_DIR=$NIX_BUILD_TOP
-      # https://github.com/NixOS/nixpkgs/issues/109033
-      args=("$@")
-      for ((i=0; i<"''${#args[@]}"; i++)); do
-        case ''${args[i]} in
-          -frandom-seed=*) unset args[i]; break;;
-        esac
-      done
-      set -- "''${args[@]}"
-      [ -d $CCACHE_DIR ] || exec ${cc}/bin/$(basename "$0") "$@"
-    '';
-  }).overrideAttrs (old: {
-    # https://github.com/NixOS/nixpkgs/issues/119779
-    installPhase = builtins.replaceStrings [ "use_response_file_by_default=1" ] [ "use_response_file_by_default=0" ] old.installPhase;
-  });
-  stdenv' = if stdenv.isLinux then useGoldLinker stdenv else stdenv;
   lean = callPackage bootstrap (args // {
-    stdenv = overrideCC stdenv' cc;
+    inherit (llvmPackages) stdenv;
     inherit src buildLeanPackage llvmPackages;
   });
+
   makeOverridableLeanPackage = f:
     let
       newF = origArgs: f origArgs // {
@@ -36,19 +20,11 @@ let
     lib.setFunctionArgs newF (lib.functionArgs f) // {
       override = args: makeOverridableLeanPackage (f.override args);
     };
+
   buildLeanPackage = makeOverridableLeanPackage (callPackage (import "${src}/nix/buildLeanPackage.nix") (args // {
     inherit (lean) stdenv;
     lean = lean.stage1;
     inherit (lean.stage1) leanc;
   }));
 in
-{
-  inherit cc buildLeanPackage llvmPackages;
-  nixpkgs = pkgs;
-  ciShell = writeShellScriptBin "ciShell" ''
-    set -o pipefail
-    export PATH=${moreutils}/bin:$PATH
-    # prefix lines with cumulative and individual execution time
-    "$@" |& ts -i "(%.S)]" | ts -s "[%M:%S"
-  '';
-} // lean.stage1
+{ inherit buildLeanPackage; } // lean.stage1

--- a/manifests/v4.11.0.nix
+++ b/manifests/v4.11.0.nix
@@ -1,212 +1,244 @@
 {
   tag = "v4.11.0";
   rev = "ec3042d94bd11a42430f9e14d39e26b1f880f99b";
-	bootstrap = { src, debug ? false, stage0debug ? false, extraCMakeFlags ? [],
-	  stdenv, lib, cmake, gmp, git, gnumake, bash, buildLeanPackage, writeShellScriptBin, runCommand, symlinkJoin, lndir, perl, gnused, darwin, llvmPackages, linkFarmFromDrvs,
-	  ... } @ args:
-	with builtins; rec {
-	  inherit stdenv;
-	  sourceByRegex = p: rs: lib.sourceByRegex p (map (r: "(/src/)?${r}") rs);
-	  buildCMake = args: stdenv.mkDerivation ({
-	    nativeBuildInputs = [ cmake ];
-	    buildInputs = [ gmp llvmPackages.llvm ];
-	    # https://github.com/NixOS/nixpkgs/issues/60919
-	    hardeningDisable = [ "all" ];
-	    dontStrip = (args.debug or debug);
+  bootstrap =
+    { src
+    , debug ? false
+    , stage0debug ? false
+    , extraCMakeFlags ? [ ]
+    , stdenv
+    , lib
+    , cmake
+    , gmp
+    , git
+    , gnumake
+    , bash
+    , buildLeanPackage
+    , writeShellScriptBin
+    , runCommand
+    , symlinkJoin
+    , lndir
+    , perl
+    , gnused
+    , darwin
+    , llvmPackages
+    , linkFarmFromDrvs
+    , ...
+    } @ args:
+      with builtins; rec {
+        inherit stdenv;
+        sourceByRegex = p: rs: lib.sourceByRegex p (map (r: "(/src/)?${r}") rs);
+        buildCMake = args: stdenv.mkDerivation ({
+          nativeBuildInputs = [ cmake ];
+          buildInputs = [ gmp llvmPackages.llvm ];
+          # https://github.com/NixOS/nixpkgs/issues/60919
+          hardeningDisable = [ "all" ];
+          dontStrip = (args.debug or debug);
 
-	    postConfigure = ''
-	      patchShebangs .
-	    '';
-	  } // args // {
-	    src = args.realSrc or (sourceByRegex args.src [ "[a-z].*" "CMakeLists\.txt" ]);
-	    cmakeFlags = (args.cmakeFlags or [ "-DSTAGE=1" "-DPREV_STAGE=./faux-prev-stage" "-DUSE_GITHASH=OFF" ]) ++ (args.extraCMakeFlags or extraCMakeFlags) ++ lib.optional (args.debug or debug) [ "-DCMAKE_BUILD_TYPE=Debug" ];
-	    preConfigure = args.preConfigure or "" + ''
-	      # ignore absence of submodule
-	      sed -i 's!lake/Lake.lean!!' CMakeLists.txt
-	    '';
-	  });
-	  lean-bin-tools-unwrapped = buildCMake {
-	    name = "lean-bin-tools";
-	    outputs = [ "out" "leanc_src" ];
-	    realSrc = sourceByRegex (src + "/src") [ "CMakeLists\.txt" "cmake.*" "bin.*" "include.*" ".*\.in" "Leanc\.lean" ];
-	    preConfigure = ''
-	      touch empty.cpp
-	      sed -i 's/add_subdirectory.*//;s/set(LEAN_OBJS.*/set(LEAN_OBJS empty.cpp)/' CMakeLists.txt
-	    '';
-	    dontBuild = true;
-	    installPhase = ''
-	      mkdir $out $leanc_src
-	      mv bin/ include/ share/ $out/
-	      mv leanc.sh $out/bin/leanc
-	      mv leanc/Leanc.lean $leanc_src/
-	      substituteInPlace $out/bin/leanc --replace '$root' "$out" --replace " sed " " ${gnused}/bin/sed "
-	      substituteInPlace $out/bin/leanmake --replace "make" "${gnumake}/bin/make"
-	      substituteInPlace $out/share/lean/lean.mk --replace "/usr/bin/env bash" "${bash}/bin/bash"
-	    '';
-	  };
-	  leancpp = buildCMake {
-	    name = "leancpp";
-	    src = src + "/src";
-	    buildFlags = [ "leancpp" "leanrt" "leanrt_initial-exec" "shell" ];
-	    installPhase = ''
-	      mkdir -p $out
-	      mv lib/ $out/
-	      mv shell/CMakeFiles/shell.dir/lean.cpp.o $out/lib
-	      mv runtime/libleanrt_initial-exec.a $out/lib
-	    '';
-	  };
-	  stage0 = args.stage0 or (buildCMake {
-	    name = "lean-stage0";
-	    realSrc = src + "/stage0/src";
-	    debug = stage0debug;
-	    cmakeFlags = [ "-DSTAGE=0" ];
-	    extraCMakeFlags = [];
-	    preConfigure = ''
-	      ln -s ${src + "/stage0/stdlib"} ../stdlib
-	    '';
-	    installPhase = ''
-	      mkdir -p $out/bin $out/lib/lean
-	      mv bin/lean $out/bin/
-	      mv lib/lean/*.{so,dylib} $out/lib/lean
-	    '';
-	    meta.mainProgram = "lean";
-	  });
-	  stage = { stage, prevStage, self }:
-	    let
-	      desc = "stage${toString stage}";
-	      build = args: buildLeanPackage.override {
-	        lean = prevStage;
-	        leanc = lean-bin-tools-unwrapped;
-	        # use same stage for retrieving dependencies
-	        lean-leanDeps = stage0;
-	        lean-final = self;
-	      } ({
-	        src = src + "/src";
-	        roots = [ { mod = args.name; glob = "andSubmodules"; } ];
-	        fullSrc = src;
-	        srcPath = "$PWD/src:$PWD/src/lake";
-	        inherit debug;
-	        leanFlags = [ "-DwarningAsError=true" ];
-	      } // args);
-	      Init' = build { name = "Init"; deps = []; };
-	      Std' = build { name = "Std"; deps = [ Init' ]; };
-	      Lean' = build { name = "Lean"; deps = [ Std' ]; };
-	      attachSharedLib = sharedLib: pkg: pkg // {
-	        inherit sharedLib;
-	        mods = mapAttrs (_: m: m // { inherit sharedLib; propagatedLoadDynlibs = []; }) pkg.mods;
-	      };
-	    in (all: all // all.lean) rec {
-	      inherit (Lean) emacs-dev emacs-package vscode-dev vscode-package;
-	      Init = attachSharedLib leanshared Init';
-	      Std = attachSharedLib leanshared Std' // { allExternalDeps = [ Init ]; };
-	      Lean = attachSharedLib leanshared Lean' // { allExternalDeps = [ Std ]; };
-	      Lake = build {
-	        name = "Lake";
-	        src = src + "/src/lake";
-	        deps = [ Init Lean ];
-	      };
-	      Lake-Main = build {
-	        name = "Lake.Main";
-	        roots = [ "Lake.Main" ];
-	        executableName = "lake";
-	        deps = [ Lake ];
-	        linkFlags = lib.optional stdenv.isLinux "-rdynamic";
-	        src = src + "/src/lake";
-	      };
-	      stdlib = [ Init Std Lean Lake ];
-	      modDepsFiles = symlinkJoin { name = "modDepsFiles"; paths = map (l: l.modDepsFile) (stdlib ++ [ Leanc ]); };
-	      depRoots = symlinkJoin { name = "depRoots"; paths = map (l: l.depRoots) stdlib; };
-	      iTree = symlinkJoin { name = "ileans"; paths = map (l: l.iTree) stdlib; };
-	      Leanc = build { name = "Leanc"; src = lean-bin-tools-unwrapped.leanc_src; deps = stdlib; roots = [ "Leanc" ]; };
-	      stdlibLinkFlags = "${lib.concatMapStringsSep " " (l: "-L${l.staticLib}") stdlib} -L${leancpp}/lib/lean";
-	      libInit_shared = runCommand "libInit_shared" { buildInputs = [ stdenv.cc ]; libName = "libInit_shared${stdenv.hostPlatform.extensions.sharedLibrary}"; } ''
-	        mkdir $out
-	        touch empty.c
-	        ${stdenv.cc}/bin/cc -shared -o $out/$libName empty.c
-	      '';
-	      leanshared = runCommand "leanshared" { buildInputs = [ stdenv.cc ]; libName = "libleanshared${stdenv.hostPlatform.extensions.sharedLibrary}"; } ''
-	        mkdir $out
-	        LEAN_CC=${stdenv.cc}/bin/cc ${lean-bin-tools-unwrapped}/bin/leanc -shared ${lib.optionalString stdenv.isLinux "-Wl,-Bsymbolic"} \
-	          ${if stdenv.isDarwin
-	            then "-Wl,-force_load,${Init.staticLib}/libInit.a -Wl,-force_load,${Std.staticLib}/libStd.a -Wl,-force_load,${Lean.staticLib}/libLean.a -Wl,-force_load,${leancpp}/lib/lean/libleancpp.a ${leancpp}/lib/libleanrt_initial-exec.a -lc++"
-	            else "-Wl,--whole-archive -lInit -lStd -lLean -lleancpp ${leancpp}/lib/libleanrt_initial-exec.a -Wl,--no-whole-archive -lstdc++"} \
-	          -lm ${stdlibLinkFlags} \
-	          $(${llvmPackages.libllvm.dev}/bin/llvm-config --ldflags --libs) \
-	          -o $out/$libName
-	      '';
-	      mods = foldl' (mods: pkg: mods // pkg.mods) {} stdlib;
-	      print-paths = Lean.makePrintPathsFor [] mods;
-	      leanc = writeShellScriptBin "leanc" ''
-	        LEAN_CC=${stdenv.cc}/bin/cc ${Leanc.executable}/bin/leanc -I${lean-bin-tools-unwrapped}/include ${stdlibLinkFlags} -L${libInit_shared} -L${leanshared} "$@"
-	      '';
-	      lean = runCommand "lean" { buildInputs = lib.optional stdenv.isDarwin darwin.cctools; } ''
-	        mkdir -p $out/bin
-	        ${leanc}/bin/leanc ${leancpp}/lib/lean.cpp.o ${libInit_shared}/* ${leanshared}/* -o $out/bin/lean
-	      '';
-	      # derivation following the directory layout of the "basic" setup, mostly useful for running tests
-	      lean-all = stdenv.mkDerivation {
-	        name = "lean-${desc}";
-	        buildCommand = ''
-	          mkdir -p $out/bin $out/lib/lean
-	          ln -sf ${leancpp}/lib/lean/* ${lib.concatMapStringsSep " " (l: "${l.modRoot}/* ${l.staticLib}/*") (lib.reverseList stdlib)} ${libInit_shared}/* ${leanshared}/* $out/lib/lean/
-	          # put everything in a single final derivation so `IO.appDir` references work
-	          cp ${lean}/bin/lean ${leanc}/bin/leanc ${Lake-Main.executable}/bin/lake $out/bin
-	          # NOTE: `lndir` will not override existing `bin/leanc`
-	          ${lndir}/bin/lndir -silent ${lean-bin-tools-unwrapped} $out
-	        '';
-	        meta.mainProgram = "lean";
-	      };
-	      cacheRoots = linkFarmFromDrvs "cacheRoots" ([
-	        stage0 lean leanc lean-all iTree modDepsFiles depRoots Leanc.src
-	      ] ++ map (lib: lib.oTree) stdlib);
-	      test = buildCMake {
-	        name = "lean-test-${desc}";
-	        realSrc = lib.sourceByRegex src [ "src.*" "tests.*" ];
-	        buildInputs = [ gmp perl git ];
-	        preConfigure = ''
-	          cd src
-	        '';
-	        extraCMakeFlags = [ "-DLLVM=OFF" ];
-	        postConfigure = ''
-	          patchShebangs ../../tests ../lake
-	          rm -r bin lib include share
-	          ln -sf ${lean-all}/* .
-	        '';
-	        buildPhase = ''
-	          ctest --output-junit test-results.xml --output-on-failure -E 'leancomptest_(doc_example|foreign)' -j$NIX_BUILD_CORES
-	        '';
-	        installPhase = ''
-	          mkdir $out
-	          mv test-results.xml $out
-	        '';
-	      };
-	      update-stage0 =
-	        let cTree = symlinkJoin { name = "cs"; paths = map (lib: lib.cTree) stdlib; }; in
-	        writeShellScriptBin "update-stage0" ''
-	          CSRCS=${cTree} CP_C_PARAMS="--dereference --no-preserve=all" ${src + "/script/lib/update-stage0"}
-	        '';
-	      update-stage0-commit = writeShellScriptBin "update-stage0-commit" ''
-	        set -euo pipefail
-	        ${update-stage0}/bin/update-stage0
-	        git commit -m "chore: update stage0"
-	      '';
-	      link-ilean = writeShellScriptBin "link-ilean" ''
-	        dest=''${1:-src}
-	        rm -rf $dest/build/lib || true
-	        mkdir -p $dest/build/lib
-	        ln -s ${iTree}/* $dest/build/lib
-	      '';
-	      benchmarks =
-	        let
-	          entries = attrNames (readDir (src + "/tests/bench"));
-	          leanFiles = map (n: elemAt n 0) (filter (n: n != null) (map (match "(.*)\.lean") entries));
-	        in lib.genAttrs leanFiles (n: (buildLeanPackage {
-	          name = n;
-	          src = filterSource (e: _: baseNameOf e == "${n}.lean") (src + "/tests/bench");
-	        }).executable);
-	    };
-	  stage1 = stage { stage = 1; prevStage = stage0; self = stage1; };
-	  stage2 = stage { stage = 2; prevStage = stage1; self = stage2; };
-	  stage3 = stage { stage = 3; prevStage = stage2; self = stage3; };
-	};
+          postConfigure = ''
+            	      patchShebangs .
+            	    '';
+        } // args // {
+          src = args.realSrc or (sourceByRegex args.src [ "[a-z].*" "CMakeLists\.txt" ]);
+          cmakeFlags = (args.cmakeFlags or [ "-DSTAGE=1" "-DPREV_STAGE=./faux-prev-stage" "-DUSE_GITHASH=OFF" ]) ++ (args.extraCMakeFlags or extraCMakeFlags) ++ lib.optional (args.debug or debug) [ "-DCMAKE_BUILD_TYPE=Debug" ];
+          preConfigure = args.preConfigure or "" + ''
+            	      # ignore absence of submodule
+            	      sed -i 's!lake/Lake.lean!!' CMakeLists.txt
+            	    '';
+        });
+        lean-bin-tools-unwrapped = buildCMake {
+          name = "lean-bin-tools";
+          outputs = [ "out" "leanc_src" ];
+          realSrc = sourceByRegex (src + "/src") [ "CMakeLists\.txt" "cmake.*" "bin.*" "include.*" ".*\.in" "Leanc\.lean" ];
+          preConfigure = ''
+            	      touch empty.cpp
+            	      sed -i 's/add_subdirectory.*//;s/set(LEAN_OBJS.*/set(LEAN_OBJS empty.cpp)/' CMakeLists.txt
+            	    '';
+          dontBuild = true;
+          installPhase = ''
+            	      mkdir $out $leanc_src
+            	      mv bin/ include/ share/ $out/
+            	      mv leanc.sh $out/bin/leanc
+            	      mv leanc/Leanc.lean $leanc_src/
+            	      substituteInPlace $out/bin/leanc --replace '$root' "$out" --replace " sed " " ${gnused}/bin/sed "
+            	      substituteInPlace $out/bin/leanmake --replace "make" "${gnumake}/bin/make"
+            	      substituteInPlace $out/share/lean/lean.mk --replace "/usr/bin/env bash" "${bash}/bin/bash"
+            	    '';
+        };
+        leancpp = buildCMake {
+          name = "leancpp";
+          src = src + "/src";
+          buildFlags = [ "leancpp" "leanrt" "leanrt_initial-exec" "shell" ];
+          installPhase = ''
+            	      mkdir -p $out
+            	      mv lib/ $out/
+            	      mv shell/CMakeFiles/shell.dir/lean.cpp.o $out/lib
+            	      mv runtime/libleanrt_initial-exec.a $out/lib
+            	    '';
+        };
+        stage0 = args.stage0 or (buildCMake {
+          name = "lean-stage0";
+          realSrc = src + "/stage0/src";
+          debug = stage0debug;
+          cmakeFlags = [ "-DSTAGE=0" ];
+          extraCMakeFlags = [ ];
+          preConfigure = ''
+            	      ln -s ${src + "/stage0/stdlib"} ../stdlib
+            	    '';
+          installPhase = ''
+            	      mkdir -p $out/bin $out/lib/lean
+            	      mv bin/lean $out/bin/
+            	      mv lib/lean/*.{so,dylib} $out/lib/lean
+            	    '';
+          meta.mainProgram = "lean";
+        });
+        stage = { stage, prevStage, self }:
+          let
+            desc = "stage${toString stage}";
+            build = args: buildLeanPackage.override
+              {
+                lean = prevStage;
+                leanc = lean-bin-tools-unwrapped;
+                # use same stage for retrieving dependencies
+                lean-leanDeps = stage0;
+                lean-final = self;
+              }
+              ({
+                src = src + "/src";
+                roots = [{ mod = args.name; glob = "andSubmodules"; }];
+                fullSrc = src;
+                srcPath = "$PWD/src:$PWD/src/lake";
+                inherit debug;
+                leanFlags = [ "-DwarningAsError=true" ];
+              } // args);
+            Init' = build { name = "Init"; deps = [ ]; };
+            Std' = build { name = "Std"; deps = [ Init' ]; };
+            Lean' = build { name = "Lean"; deps = [ Std' ]; };
+            attachSharedLib = sharedLib: pkg: pkg // {
+              inherit sharedLib;
+              mods = mapAttrs (_: m: m // { inherit sharedLib; propagatedLoadDynlibs = [ ]; }) pkg.mods;
+            };
+          in
+          (all: all // all.lean) rec {
+            inherit (Lean) emacs-dev emacs-package vscode-dev vscode-package;
+            Init = attachSharedLib leanshared Init';
+            Std = attachSharedLib leanshared Std' // { allExternalDeps = [ Init ]; };
+            Lean = attachSharedLib leanshared Lean' // { allExternalDeps = [ Std ]; };
+            Lake = build {
+              name = "Lake";
+              src = src + "/src/lake";
+              deps = [ Init Lean ];
+            };
+            Lake-Main = build {
+              name = "Lake.Main";
+              roots = [ "Lake.Main" ];
+              executableName = "lake";
+              deps = [ Lake ];
+              linkFlags = lib.optional stdenv.isLinux "-rdynamic";
+              src = src + "/src/lake";
+            };
+            stdlib = [ Init Std Lean Lake ];
+            modDepsFiles = symlinkJoin { name = "modDepsFiles"; paths = map (l: l.modDepsFile) (stdlib ++ [ Leanc ]); };
+            depRoots = symlinkJoin { name = "depRoots"; paths = map (l: l.depRoots) stdlib; };
+            iTree = symlinkJoin { name = "ileans"; paths = map (l: l.iTree) stdlib; };
+            Leanc = build { name = "Leanc"; src = lean-bin-tools-unwrapped.leanc_src; deps = stdlib; roots = [ "Leanc" ]; };
+            stdlibLinkFlags = "${lib.concatMapStringsSep " " (l: "-L${l.staticLib}") stdlib} -L${leancpp}/lib/lean";
+            libInit_shared = runCommand "libInit_shared" { buildInputs = [ stdenv.cc ]; libName = "libInit_shared${stdenv.hostPlatform.extensions.sharedLibrary}"; } ''
+              	        mkdir $out
+              	        touch empty.c
+              	        ${stdenv.cc}/bin/cc -shared -o $out/$libName empty.c
+              	      '';
+            leanshared = runCommand "leanshared" { buildInputs = [ stdenv.cc ]; libName = "libleanshared${stdenv.hostPlatform.extensions.sharedLibrary}"; } ''
+              	        mkdir $out
+              	        LEAN_CC=${stdenv.cc}/bin/cc ${lean-bin-tools-unwrapped}/bin/leanc -shared ${lib.optionalString stdenv.isLinux "-Wl,-Bsymbolic"} \
+              	          ${if stdenv.isDarwin
+              	            then "-Wl,-force_load,${Init.staticLib}/libInit.a -Wl,-force_load,${Std.staticLib}/libStd.a -Wl,-force_load,${Lean.staticLib}/libLean.a -Wl,-force_load,${leancpp}/lib/lean/libleancpp.a ${leancpp}/lib/libleanrt_initial-exec.a -lc++"
+              	            else "-Wl,--whole-archive -lInit -lStd -lLean -lleancpp ${leancpp}/lib/libleanrt_initial-exec.a -Wl,--no-whole-archive -lstdc++"} \
+              	          -lm ${stdlibLinkFlags} \
+              	          $(${llvmPackages.libllvm.dev}/bin/llvm-config --ldflags --libs) \
+              	          -o $out/$libName
+              	      '';
+            mods = foldl' (mods: pkg: mods // pkg.mods) { } stdlib;
+            print-paths = Lean.makePrintPathsFor [ ] mods;
+            leanc = writeShellScriptBin "leanc" ''
+              	        LEAN_CC=${stdenv.cc}/bin/cc ${Leanc.executable}/bin/leanc -I${lean-bin-tools-unwrapped}/include ${stdlibLinkFlags} -L${libInit_shared} -L${leanshared} "$@"
+              	      '';
+            lean = runCommand "lean" { buildInputs = lib.optional stdenv.isDarwin darwin.cctools; } ''
+              	        mkdir -p $out/bin
+              	        ${leanc}/bin/leanc ${leancpp}/lib/lean.cpp.o ${libInit_shared}/* ${leanshared}/* -o $out/bin/lean
+              	      '';
+            # derivation following the directory layout of the "basic" setup, mostly useful for running tests
+            lean-all = stdenv.mkDerivation {
+              name = "lean-${desc}";
+              buildCommand = ''
+                	          mkdir -p $out/bin $out/lib/lean
+                	          ln -sf ${leancpp}/lib/lean/* ${lib.concatMapStringsSep " " (l: "${l.modRoot}/* ${l.staticLib}/*") (lib.reverseList stdlib)} ${libInit_shared}/* ${leanshared}/* $out/lib/lean/
+                	          # put everything in a single final derivation so `IO.appDir` references work
+                	          cp ${lean}/bin/lean ${leanc}/bin/leanc ${Lake-Main.executable}/bin/lake $out/bin
+                	          # NOTE: `lndir` will not override existing `bin/leanc`
+                	          ${lndir}/bin/lndir -silent ${lean-bin-tools-unwrapped} $out
+                	        '';
+              meta.mainProgram = "lean";
+            };
+            cacheRoots = linkFarmFromDrvs "cacheRoots" ([
+              stage0
+              lean
+              leanc
+              lean-all
+              iTree
+              modDepsFiles
+              depRoots
+              Leanc.src
+            ] ++ map (lib: lib.oTree) stdlib);
+            test = buildCMake {
+              name = "lean-test-${desc}";
+              realSrc = lib.sourceByRegex src [ "src.*" "tests.*" ];
+              buildInputs = [ gmp perl git ];
+              preConfigure = ''
+                	          cd src
+                	        '';
+              extraCMakeFlags = [ "-DLLVM=OFF" ];
+              postConfigure = ''
+                	          patchShebangs ../../tests ../lake
+                	          rm -r bin lib include share
+                	          ln -sf ${lean-all}/* .
+                	        '';
+              buildPhase = ''
+                	          ctest --output-junit test-results.xml --output-on-failure -E 'leancomptest_(doc_example|foreign)' -j$NIX_BUILD_CORES
+                	        '';
+              installPhase = ''
+                	          mkdir $out
+                	          mv test-results.xml $out
+                	        '';
+            };
+            update-stage0 =
+              let cTree = symlinkJoin { name = "cs"; paths = map (lib: lib.cTree) stdlib; }; in
+              writeShellScriptBin "update-stage0" ''
+                	          CSRCS=${cTree} CP_C_PARAMS="--dereference --no-preserve=all" ${src + "/script/lib/update-stage0"}
+                	        '';
+            update-stage0-commit = writeShellScriptBin "update-stage0-commit" ''
+              	        set -euo pipefail
+              	        ${update-stage0}/bin/update-stage0
+              	        git commit -m "chore: update stage0"
+              	      '';
+            link-ilean = writeShellScriptBin "link-ilean" ''
+              	        dest=''${1:-src}
+              	        rm -rf $dest/build/lib || true
+              	        mkdir -p $dest/build/lib
+              	        ln -s ${iTree}/* $dest/build/lib
+              	      '';
+            benchmarks =
+              let
+                entries = attrNames (readDir (src + "/tests/bench"));
+                leanFiles = map (n: elemAt n 0) (filter (n: n != null) (map (match "(.*)\.lean") entries));
+              in
+              lib.genAttrs leanFiles (n: (buildLeanPackage {
+                name = n;
+                src = filterSource (e: _: baseNameOf e == "${n}.lean") (src + "/tests/bench");
+              }).executable);
+          };
+        stage1 = stage { stage = 1; prevStage = stage0; self = stage1; };
+        stage2 = stage { stage = 2; prevStage = stage1; self = stage2; };
+        stage3 = stage { stage = 3; prevStage = stage2; self = stage3; };
+      };
 }

--- a/manifests/v4.12.0.nix
+++ b/manifests/v4.12.0.nix
@@ -2,212 +2,246 @@
   tag = "v4.12.0";
   rev = "dc2533473114eb8656439ff2b9335209784aa640";
 
-  bootstrap = { src, debug ? false, stage0debug ? false, extraCMakeFlags ? [],
-	  stdenv, lib, cmake, gmp, libuv, cadical, git, gnumake, bash, buildLeanPackage, writeShellScriptBin, runCommand, symlinkJoin, lndir, perl, gnused, darwin, llvmPackages, linkFarmFromDrvs,
-	  ... } @ args:
-	with builtins; rec {
-	  inherit stdenv;
-	  sourceByRegex = p: rs: lib.sourceByRegex p (map (r: "(/src/)?${r}") rs);
-	  buildCMake = args: stdenv.mkDerivation ({
-	    nativeBuildInputs = [ cmake ];
-	    buildInputs = [ gmp libuv llvmPackages.llvm ];
-	    # https://github.com/NixOS/nixpkgs/issues/60919
-	    hardeningDisable = [ "all" ];
-	    dontStrip = (args.debug or debug);
+  bootstrap =
+    { src
+    , debug ? false
+    , stage0debug ? false
+    , extraCMakeFlags ? [ ]
+    , stdenv
+    , lib
+    , cmake
+    , gmp
+    , libuv
+    , cadical
+    , git
+    , gnumake
+    , bash
+    , buildLeanPackage
+    , writeShellScriptBin
+    , runCommand
+    , symlinkJoin
+    , lndir
+    , perl
+    , gnused
+    , darwin
+    , llvmPackages
+    , linkFarmFromDrvs
+    , ...
+    } @ args:
+      with builtins; rec {
+        inherit stdenv;
+        sourceByRegex = p: rs: lib.sourceByRegex p (map (r: "(/src/)?${r}") rs);
+        buildCMake = args: stdenv.mkDerivation ({
+          nativeBuildInputs = [ cmake ];
+          buildInputs = [ gmp libuv llvmPackages.llvm ];
+          # https://github.com/NixOS/nixpkgs/issues/60919
+          hardeningDisable = [ "all" ];
+          dontStrip = (args.debug or debug);
 
-	    postConfigure = ''
-	      patchShebangs .
-	    '';
-	  } // args // {
-	    src = args.realSrc or (sourceByRegex args.src [ "[a-z].*" "CMakeLists\.txt" ]);
-	    cmakeFlags = (args.cmakeFlags or [ "-DSTAGE=1" "-DPREV_STAGE=./faux-prev-stage" "-DUSE_GITHASH=OFF" "-DCADICAL=${cadical}/bin/cadical" ]) ++ (args.extraCMakeFlags or extraCMakeFlags) ++ lib.optional (args.debug or debug) [ "-DCMAKE_BUILD_TYPE=Debug" ];
-	    preConfigure = args.preConfigure or "" + ''
-	      # ignore absence of submodule
-	      sed -i 's!lake/Lake.lean!!' CMakeLists.txt
-	    '';
-	  });
-	  lean-bin-tools-unwrapped = buildCMake {
-	    name = "lean-bin-tools";
-	    outputs = [ "out" "leanc_src" ];
-	    realSrc = sourceByRegex (src + "/src") [ "CMakeLists\.txt" "[a-z].*" ".*\.in" "Leanc\.lean" ];
-	    dontBuild = true;
-	    installPhase = ''
-	      mkdir $out $leanc_src
-	      mv bin/ include/ share/ $out/
-	      mv leanc.sh $out/bin/leanc
-	      mv leanc/Leanc.lean $leanc_src/
-	      substituteInPlace $out/bin/leanc --replace '$root' "$out" --replace " sed " " ${gnused}/bin/sed "
-	      substituteInPlace $out/bin/leanmake --replace "make" "${gnumake}/bin/make"
-	      substituteInPlace $out/share/lean/lean.mk --replace "/usr/bin/env bash" "${bash}/bin/bash"
-	    '';
-	  };
-	  leancpp = buildCMake {
-	    name = "leancpp";
-	    src = src + "/src";
-	    buildFlags = [ "leancpp" "leanrt" "leanrt_initial-exec" "leanshell" "leanmain" ];
-	    installPhase = ''
-	      mkdir -p $out
-	      mv lib/ $out/
-	      mv runtime/libleanrt_initial-exec.a $out/lib
-	    '';
-	  };
-	  stage0 = args.stage0 or (buildCMake {
-	    name = "lean-stage0";
-	    realSrc = src + "/stage0/src";
-	    debug = stage0debug;
-	    cmakeFlags = [ "-DSTAGE=0" ];
-	    extraCMakeFlags = [];
-	    preConfigure = ''
-	      ln -s ${src + "/stage0/stdlib"} ../stdlib
-	    '';
-	    installPhase = ''
-	      mkdir -p $out/bin $out/lib/lean
-	      mv bin/lean $out/bin/
-	      mv lib/lean/*.{so,dylib} $out/lib/lean
-	    '';
-	    meta.mainProgram = "lean";
-	  });
-	  stage = { stage, prevStage, self }:
-	    let
-	      desc = "stage${toString stage}";
-	      build = args: buildLeanPackage.override {
-	        lean = prevStage;
-	        leanc = lean-bin-tools-unwrapped;
-	        # use same stage for retrieving dependencies
-	        lean-leanDeps = stage0;
-	        lean-final = self;
-	      } ({
-	        src = src + "/src";
-	        roots = [ { mod = args.name; glob = "andSubmodules"; } ];
-	        fullSrc = src;
-	        srcPath = "$PWD/src:$PWD/src/lake";
-	        inherit debug;
-	        leanFlags = [ "-DwarningAsError=true" ];
-	      } // args);
-	      Init' = build { name = "Init"; deps = []; };
-	      Std' = build { name = "Std"; deps = [ Init' ]; };
-	      Lean' = build { name = "Lean"; deps = [ Std' ]; };
-	      attachSharedLib = sharedLib: pkg: pkg // {
-	        inherit sharedLib;
-	        mods = mapAttrs (_: m: m // { inherit sharedLib; propagatedLoadDynlibs = []; }) pkg.mods;
-	      };
-	    in (all: all // all.lean) rec {
-	      inherit (Lean) emacs-dev emacs-package vscode-dev vscode-package;
-	      Init = attachSharedLib leanshared Init';
-	      Std = attachSharedLib leanshared Std' // { allExternalDeps = [ Init ]; };
-	      Lean = attachSharedLib leanshared Lean' // { allExternalDeps = [ Std ]; };
-	      Lake = build {
-	        name = "Lake";
-	        src = src + "/src/lake";
-	        deps = [ Init Lean ];
-	      };
-	      Lake-Main = build {
-	        name = "Lake.Main";
-	        roots = [ "Lake.Main" ];
-	        executableName = "lake";
-	        deps = [ Lake ];
-	        linkFlags = lib.optional stdenv.isLinux "-rdynamic";
-	        src = src + "/src/lake";
-	      };
-	      stdlib = [ Init Std Lean Lake ];
-	      modDepsFiles = symlinkJoin { name = "modDepsFiles"; paths = map (l: l.modDepsFile) (stdlib ++ [ Leanc ]); };
-	      depRoots = symlinkJoin { name = "depRoots"; paths = map (l: l.depRoots) stdlib; };
-	      iTree = symlinkJoin { name = "ileans"; paths = map (l: l.iTree) stdlib; };
-	      Leanc = build { name = "Leanc"; src = lean-bin-tools-unwrapped.leanc_src; deps = stdlib; roots = [ "Leanc" ]; };
-	      stdlibLinkFlags = "${lib.concatMapStringsSep " " (l: "-L${l.staticLib}") stdlib} -L${leancpp}/lib/lean -L${leancpp}/lib/temp";
-	      libInit_shared = runCommand "libInit_shared" { buildInputs = [ stdenv.cc ]; libName = "libInit_shared${stdenv.hostPlatform.extensions.sharedLibrary}"; } ''
-	        mkdir $out
-	        touch empty.c
-	        ${stdenv.cc}/bin/cc -shared -o $out/$libName empty.c
-	      '';
-	      leanshared_1 = runCommand "leanshared_1" { buildInputs = [ stdenv.cc ]; libName = "leanshared_1${stdenv.hostPlatform.extensions.sharedLibrary}"; } ''
-	        mkdir $out
-	        touch empty.c
-	        ${stdenv.cc}/bin/cc -shared -o $out/$libName empty.c
-	      '';
-	      leanshared = runCommand "leanshared" { buildInputs = [ stdenv.cc ]; libName = "libleanshared${stdenv.hostPlatform.extensions.sharedLibrary}"; } ''
-	        mkdir $out
-	        LEAN_CC=${stdenv.cc}/bin/cc ${lean-bin-tools-unwrapped}/bin/leanc -shared ${lib.optionalString stdenv.isLinux "-Wl,-Bsymbolic"} \
-	          ${if stdenv.isDarwin
-	            then "-Wl,-force_load,${Init.staticLib}/libInit.a -Wl,-force_load,${Std.staticLib}/libStd.a -Wl,-force_load,${Lean.staticLib}/libLean.a -Wl,-force_load,${leancpp}/lib/lean/libleancpp.a ${leancpp}/lib/libleanrt_initial-exec.a ${leancpp}/lib/temp/libleanshell.a -lc++"
-						  else "-Wl,--whole-archive ${leancpp}/lib/temp/libleanshell.a -lInit -lStd -lLean -lleancpp ${leancpp}/lib/libleanrt_initial-exec.a -Wl,--no-whole-archive -lstdc++"} \
-	          -lm ${stdlibLinkFlags} \
-	          $(${llvmPackages.libllvm.dev}/bin/llvm-config --ldflags --libs) \
-	          -o $out/$libName
-	      '';
-	      mods = foldl' (mods: pkg: mods // pkg.mods) {} stdlib;
-	      print-paths = Lean.makePrintPathsFor [] mods;
-	      leanc = writeShellScriptBin "leanc" ''
-	        LEAN_CC=${stdenv.cc}/bin/cc ${Leanc.executable}/bin/leanc -I${lean-bin-tools-unwrapped}/include ${stdlibLinkFlags} -L${libInit_shared} -L${leanshared_1} -L${leanshared} "$@"
-	      '';
-	      lean = runCommand "lean" { buildInputs = lib.optional stdenv.isDarwin darwin.cctools; } ''
-	        mkdir -p $out/bin
-	        ${leanc}/bin/leanc ${leancpp}/lib/temp/libleanmain.a ${if stdenv.isDarwin then "${leancpp}/lib/temp/libleanshell.a" else ""} ${libInit_shared}/* ${leanshared_1}/* ${leanshared}/* -o $out/bin/lean
-	      '';
-	      # derivation following the directory layout of the "basic" setup, mostly useful for running tests
-	      lean-all = stdenv.mkDerivation {
-	        name = "lean-${desc}";
-	        buildCommand = ''
-	          mkdir -p $out/bin $out/lib/lean
-	          ln -sf ${leancpp}/lib/lean/* ${lib.concatMapStringsSep " " (l: "${l.modRoot}/* ${l.staticLib}/*") (lib.reverseList stdlib)} ${libInit_shared}/* ${leanshared_1}/* ${leanshared}/* $out/lib/lean/
-	          # put everything in a single final derivation so `IO.appDir` references work
-	          cp ${lean}/bin/lean ${leanc}/bin/leanc ${Lake-Main.executable}/bin/lake $out/bin
-	          # NOTE: `lndir` will not override existing `bin/leanc`
-	          ${lndir}/bin/lndir -silent ${lean-bin-tools-unwrapped} $out
-	        '';
-	        meta.mainProgram = "lean";
-	      };
-	      cacheRoots = linkFarmFromDrvs "cacheRoots" ([
-	        stage0 lean leanc lean-all iTree modDepsFiles depRoots Leanc.src
-	      ] ++ map (lib: lib.oTree) stdlib);
-	      test = buildCMake {
-	        name = "lean-test-${desc}";
-	        realSrc = lib.sourceByRegex src [ "src.*" "tests.*" ];
-	        buildInputs = [ gmp libuv perl git cadical ];
-	        preConfigure = ''
-	          cd src
-	        '';
-	        extraCMakeFlags = [ "-DLLVM=OFF" ];
-	        postConfigure = ''
-	          patchShebangs ../../tests ../lake
-	          rm -r bin lib include share
-	          ln -sf ${lean-all}/* .
-	        '';
-	        buildPhase = ''
-	          ctest --output-junit test-results.xml --output-on-failure -E 'leancomptest_(doc_example|foreign)|leanlaketest_reverse-ffi' -j$NIX_BUILD_CORES
-	        '';
-	        installPhase = ''
-	          mkdir $out
-	          mv test-results.xml $out
-	        '';
-	      };
-	      update-stage0 =
-	        let cTree = symlinkJoin { name = "cs"; paths = map (lib: lib.cTree) stdlib; }; in
-	        writeShellScriptBin "update-stage0" ''
-	          CSRCS=${cTree} CP_C_PARAMS="--dereference --no-preserve=all" ${src + "/script/lib/update-stage0"}
-	        '';
-	      update-stage0-commit = writeShellScriptBin "update-stage0-commit" ''
-	        set -euo pipefail
-	        ${update-stage0}/bin/update-stage0
-	        git commit -m "chore: update stage0"
-	      '';
-	      link-ilean = writeShellScriptBin "link-ilean" ''
-	        dest=''${1:-src}
-	        rm -rf $dest/build/lib || true
-	        mkdir -p $dest/build/lib
-	        ln -s ${iTree}/* $dest/build/lib
-	      '';
-	      benchmarks =
-	        let
-	          entries = attrNames (readDir (src + "/tests/bench"));
-	          leanFiles = map (n: elemAt n 0) (filter (n: n != null) (map (match "(.*)\.lean") entries));
-	        in lib.genAttrs leanFiles (n: (buildLeanPackage {
-	          name = n;
-	          src = filterSource (e: _: baseNameOf e == "${n}.lean") (src + "/tests/bench");
-	        }).executable);
-	    };
-	  stage1 = stage { stage = 1; prevStage = stage0; self = stage1; };
-	  stage2 = stage { stage = 2; prevStage = stage1; self = stage2; };
-	  stage3 = stage { stage = 3; prevStage = stage2; self = stage3; };
-	};
+          postConfigure = ''
+            	      patchShebangs .
+            	    '';
+        } // args // {
+          src = args.realSrc or (sourceByRegex args.src [ "[a-z].*" "CMakeLists\.txt" ]);
+          cmakeFlags = (args.cmakeFlags or [ "-DSTAGE=1" "-DPREV_STAGE=./faux-prev-stage" "-DUSE_GITHASH=OFF" "-DCADICAL=${cadical}/bin/cadical" ]) ++ (args.extraCMakeFlags or extraCMakeFlags) ++ lib.optional (args.debug or debug) [ "-DCMAKE_BUILD_TYPE=Debug" ];
+          preConfigure = args.preConfigure or "" + ''
+            	      # ignore absence of submodule
+            	      sed -i 's!lake/Lake.lean!!' CMakeLists.txt
+            	    '';
+        });
+        lean-bin-tools-unwrapped = buildCMake {
+          name = "lean-bin-tools";
+          outputs = [ "out" "leanc_src" ];
+          realSrc = sourceByRegex (src + "/src") [ "CMakeLists\.txt" "[a-z].*" ".*\.in" "Leanc\.lean" ];
+          dontBuild = true;
+          installPhase = ''
+            	      mkdir $out $leanc_src
+            	      mv bin/ include/ share/ $out/
+            	      mv leanc.sh $out/bin/leanc
+            	      mv leanc/Leanc.lean $leanc_src/
+            	      substituteInPlace $out/bin/leanc --replace '$root' "$out" --replace " sed " " ${gnused}/bin/sed "
+            	      substituteInPlace $out/bin/leanmake --replace "make" "${gnumake}/bin/make"
+            	      substituteInPlace $out/share/lean/lean.mk --replace "/usr/bin/env bash" "${bash}/bin/bash"
+            	    '';
+        };
+        leancpp = buildCMake {
+          name = "leancpp";
+          src = src + "/src";
+          buildFlags = [ "leancpp" "leanrt" "leanrt_initial-exec" "leanshell" "leanmain" ];
+          installPhase = ''
+            	      mkdir -p $out
+            	      mv lib/ $out/
+            	      mv runtime/libleanrt_initial-exec.a $out/lib
+            	    '';
+        };
+        stage0 = args.stage0 or (buildCMake {
+          name = "lean-stage0";
+          realSrc = src + "/stage0/src";
+          debug = stage0debug;
+          cmakeFlags = [ "-DSTAGE=0" ];
+          extraCMakeFlags = [ ];
+          preConfigure = ''
+            	      ln -s ${src + "/stage0/stdlib"} ../stdlib
+            	    '';
+          installPhase = ''
+            	      mkdir -p $out/bin $out/lib/lean
+            	      mv bin/lean $out/bin/
+            	      mv lib/lean/*.{so,dylib} $out/lib/lean
+            	    '';
+          meta.mainProgram = "lean";
+        });
+        stage = { stage, prevStage, self }:
+          let
+            desc = "stage${toString stage}";
+            build = args: buildLeanPackage.override
+              {
+                lean = prevStage;
+                leanc = lean-bin-tools-unwrapped;
+                # use same stage for retrieving dependencies
+                lean-leanDeps = stage0;
+                lean-final = self;
+              }
+              ({
+                src = src + "/src";
+                roots = [{ mod = args.name; glob = "andSubmodules"; }];
+                fullSrc = src;
+                srcPath = "$PWD/src:$PWD/src/lake";
+                inherit debug;
+                leanFlags = [ "-DwarningAsError=true" ];
+              } // args);
+            Init' = build { name = "Init"; deps = [ ]; };
+            Std' = build { name = "Std"; deps = [ Init' ]; };
+            Lean' = build { name = "Lean"; deps = [ Std' ]; };
+            attachSharedLib = sharedLib: pkg: pkg // {
+              inherit sharedLib;
+              mods = mapAttrs (_: m: m // { inherit sharedLib; propagatedLoadDynlibs = [ ]; }) pkg.mods;
+            };
+          in
+          (all: all // all.lean) rec {
+            inherit (Lean) emacs-dev emacs-package vscode-dev vscode-package;
+            Init = attachSharedLib leanshared Init';
+            Std = attachSharedLib leanshared Std' // { allExternalDeps = [ Init ]; };
+            Lean = attachSharedLib leanshared Lean' // { allExternalDeps = [ Std ]; };
+            Lake = build {
+              name = "Lake";
+              src = src + "/src/lake";
+              deps = [ Init Lean ];
+            };
+            Lake-Main = build {
+              name = "Lake.Main";
+              roots = [ "Lake.Main" ];
+              executableName = "lake";
+              deps = [ Lake ];
+              linkFlags = lib.optional stdenv.isLinux "-rdynamic";
+              src = src + "/src/lake";
+            };
+            stdlib = [ Init Std Lean Lake ];
+            modDepsFiles = symlinkJoin { name = "modDepsFiles"; paths = map (l: l.modDepsFile) (stdlib ++ [ Leanc ]); };
+            depRoots = symlinkJoin { name = "depRoots"; paths = map (l: l.depRoots) stdlib; };
+            iTree = symlinkJoin { name = "ileans"; paths = map (l: l.iTree) stdlib; };
+            Leanc = build { name = "Leanc"; src = lean-bin-tools-unwrapped.leanc_src; deps = stdlib; roots = [ "Leanc" ]; };
+            stdlibLinkFlags = "${lib.concatMapStringsSep " " (l: "-L${l.staticLib}") stdlib} -L${leancpp}/lib/lean -L${leancpp}/lib/temp";
+            libInit_shared = runCommand "libInit_shared" { buildInputs = [ stdenv.cc ]; libName = "libInit_shared${stdenv.hostPlatform.extensions.sharedLibrary}"; } ''
+              	        mkdir $out
+              	        touch empty.c
+              	        ${stdenv.cc}/bin/cc -shared -o $out/$libName empty.c
+              	      '';
+            leanshared_1 = runCommand "leanshared_1" { buildInputs = [ stdenv.cc ]; libName = "leanshared_1${stdenv.hostPlatform.extensions.sharedLibrary}"; } ''
+              	        mkdir $out
+              	        touch empty.c
+              	        ${stdenv.cc}/bin/cc -shared -o $out/$libName empty.c
+              	      '';
+            leanshared = runCommand "leanshared" { buildInputs = [ stdenv.cc ]; libName = "libleanshared${stdenv.hostPlatform.extensions.sharedLibrary}"; } ''
+              	        mkdir $out
+              	        LEAN_CC=${stdenv.cc}/bin/cc ${lean-bin-tools-unwrapped}/bin/leanc -shared ${lib.optionalString stdenv.isLinux "-Wl,-Bsymbolic"} \
+              	          ${if stdenv.isDarwin
+              	            then "-Wl,-force_load,${Init.staticLib}/libInit.a -Wl,-force_load,${Std.staticLib}/libStd.a -Wl,-force_load,${Lean.staticLib}/libLean.a -Wl,-force_load,${leancpp}/lib/lean/libleancpp.a ${leancpp}/lib/libleanrt_initial-exec.a ${leancpp}/lib/temp/libleanshell.a -lc++"
+              						  else "-Wl,--whole-archive ${leancpp}/lib/temp/libleanshell.a -lInit -lStd -lLean -lleancpp ${leancpp}/lib/libleanrt_initial-exec.a -Wl,--no-whole-archive -lstdc++"} \
+              	          -lm ${stdlibLinkFlags} \
+              	          $(${llvmPackages.libllvm.dev}/bin/llvm-config --ldflags --libs) \
+              	          -o $out/$libName
+              	      '';
+            mods = foldl' (mods: pkg: mods // pkg.mods) { } stdlib;
+            print-paths = Lean.makePrintPathsFor [ ] mods;
+            leanc = writeShellScriptBin "leanc" ''
+              	        LEAN_CC=${stdenv.cc}/bin/cc ${Leanc.executable}/bin/leanc -I${lean-bin-tools-unwrapped}/include ${stdlibLinkFlags} -L${libInit_shared} -L${leanshared_1} -L${leanshared} "$@"
+              	      '';
+            lean = runCommand "lean" { buildInputs = lib.optional stdenv.isDarwin darwin.cctools; } ''
+              	        mkdir -p $out/bin
+              	        ${leanc}/bin/leanc ${leancpp}/lib/temp/libleanmain.a ${if stdenv.isDarwin then "${leancpp}/lib/temp/libleanshell.a" else ""} ${libInit_shared}/* ${leanshared_1}/* ${leanshared}/* -o $out/bin/lean
+              	      '';
+            # derivation following the directory layout of the "basic" setup, mostly useful for running tests
+            lean-all = stdenv.mkDerivation {
+              name = "lean-${desc}";
+              buildCommand = ''
+                	          mkdir -p $out/bin $out/lib/lean
+                	          ln -sf ${leancpp}/lib/lean/* ${lib.concatMapStringsSep " " (l: "${l.modRoot}/* ${l.staticLib}/*") (lib.reverseList stdlib)} ${libInit_shared}/* ${leanshared_1}/* ${leanshared}/* $out/lib/lean/
+                	          # put everything in a single final derivation so `IO.appDir` references work
+                	          cp ${lean}/bin/lean ${leanc}/bin/leanc ${Lake-Main.executable}/bin/lake $out/bin
+                	          # NOTE: `lndir` will not override existing `bin/leanc`
+                	          ${lndir}/bin/lndir -silent ${lean-bin-tools-unwrapped} $out
+                	        '';
+              meta.mainProgram = "lean";
+            };
+            cacheRoots = linkFarmFromDrvs "cacheRoots" ([
+              stage0
+              lean
+              leanc
+              lean-all
+              iTree
+              modDepsFiles
+              depRoots
+              Leanc.src
+            ] ++ map (lib: lib.oTree) stdlib);
+            test = buildCMake {
+              name = "lean-test-${desc}";
+              realSrc = lib.sourceByRegex src [ "src.*" "tests.*" ];
+              buildInputs = [ gmp libuv perl git cadical ];
+              preConfigure = ''
+                	          cd src
+                	        '';
+              extraCMakeFlags = [ "-DLLVM=OFF" ];
+              postConfigure = ''
+                	          patchShebangs ../../tests ../lake
+                	          rm -r bin lib include share
+                	          ln -sf ${lean-all}/* .
+                	        '';
+              buildPhase = ''
+                	          ctest --output-junit test-results.xml --output-on-failure -E 'leancomptest_(doc_example|foreign)|leanlaketest_reverse-ffi' -j$NIX_BUILD_CORES
+                	        '';
+              installPhase = ''
+                	          mkdir $out
+                	          mv test-results.xml $out
+                	        '';
+            };
+            update-stage0 =
+              let cTree = symlinkJoin { name = "cs"; paths = map (lib: lib.cTree) stdlib; }; in
+              writeShellScriptBin "update-stage0" ''
+                	          CSRCS=${cTree} CP_C_PARAMS="--dereference --no-preserve=all" ${src + "/script/lib/update-stage0"}
+                	        '';
+            update-stage0-commit = writeShellScriptBin "update-stage0-commit" ''
+              	        set -euo pipefail
+              	        ${update-stage0}/bin/update-stage0
+              	        git commit -m "chore: update stage0"
+              	      '';
+            link-ilean = writeShellScriptBin "link-ilean" ''
+              	        dest=''${1:-src}
+              	        rm -rf $dest/build/lib || true
+              	        mkdir -p $dest/build/lib
+              	        ln -s ${iTree}/* $dest/build/lib
+              	      '';
+            benchmarks =
+              let
+                entries = attrNames (readDir (src + "/tests/bench"));
+                leanFiles = map (n: elemAt n 0) (filter (n: n != null) (map (match "(.*)\.lean") entries));
+              in
+              lib.genAttrs leanFiles (n: (buildLeanPackage {
+                name = n;
+                src = filterSource (e: _: baseNameOf e == "${n}.lean") (src + "/tests/bench");
+              }).executable);
+          };
+        stage1 = stage { stage = 1; prevStage = stage0; self = stage1; };
+        stage2 = stage { stage = 2; prevStage = stage1; self = stage2; };
+        stage3 = stage { stage = 3; prevStage = stage2; self = stage3; };
+      };
 }

--- a/manifests/v4.13.0.nix
+++ b/manifests/v4.13.0.nix
@@ -1,213 +1,247 @@
 {
   tag = "v4.13.0";
   rev = "6d22e0e5cc5a4392466e3d6dd8522486d1fd038b";
-  bootstrap = { src, debug ? false, stage0debug ? false, extraCMakeFlags ? [],
-	  stdenv, lib, cmake, gmp, libuv, cadical, git, gnumake, bash, buildLeanPackage, writeShellScriptBin, runCommand, symlinkJoin, lndir, perl, gnused, darwin, llvmPackages, linkFarmFromDrvs,
-	  ... } @ args:
-	with builtins; rec {
-	  inherit stdenv;
-	  sourceByRegex = p: rs: lib.sourceByRegex p (map (r: "(/src/)?${r}") rs);
-	  buildCMake = args: stdenv.mkDerivation ({
-	    nativeBuildInputs = [ cmake ];
-	    buildInputs = [ gmp libuv llvmPackages.llvm ];
-	    # https://github.com/NixOS/nixpkgs/issues/60919
-	    hardeningDisable = [ "all" ];
-	    dontStrip = (args.debug or debug);
+  bootstrap =
+    { src
+    , debug ? false
+    , stage0debug ? false
+    , extraCMakeFlags ? [ ]
+    , stdenv
+    , lib
+    , cmake
+    , gmp
+    , libuv
+    , cadical
+    , git
+    , gnumake
+    , bash
+    , buildLeanPackage
+    , writeShellScriptBin
+    , runCommand
+    , symlinkJoin
+    , lndir
+    , perl
+    , gnused
+    , darwin
+    , llvmPackages
+    , linkFarmFromDrvs
+    , ...
+    } @ args:
+      with builtins; rec {
+        inherit stdenv;
+        sourceByRegex = p: rs: lib.sourceByRegex p (map (r: "(/src/)?${r}") rs);
+        buildCMake = args: stdenv.mkDerivation ({
+          nativeBuildInputs = [ cmake ];
+          buildInputs = [ gmp libuv llvmPackages.llvm ];
+          # https://github.com/NixOS/nixpkgs/issues/60919
+          hardeningDisable = [ "all" ];
+          dontStrip = (args.debug or debug);
 
-	    postConfigure = ''
-	      patchShebangs .
-	    '';
-	  } // args // {
-	    src = args.realSrc or (sourceByRegex args.src [ "[a-z].*" "CMakeLists\.txt" ]);
-	    cmakeFlags = (args.cmakeFlags or [ "-DSTAGE=1" "-DPREV_STAGE=./faux-prev-stage" "-DUSE_GITHASH=OFF" "-DCADICAL=${cadical}/bin/cadical" ]) ++ (args.extraCMakeFlags or extraCMakeFlags) ++ lib.optional (args.debug or debug) [ "-DCMAKE_BUILD_TYPE=Debug" ];
-	    preConfigure = args.preConfigure or "" + ''
-	      # ignore absence of submodule
-	      sed -i 's!lake/Lake.lean!!' CMakeLists.txt
-	    '';
-	  });
-	  lean-bin-tools-unwrapped = buildCMake {
-	    name = "lean-bin-tools";
-	    outputs = [ "out" "leanc_src" ];
-	    realSrc = sourceByRegex (src + "/src") [ "CMakeLists\.txt" "[a-z].*" ".*\.in" "Leanc\.lean" ];
-	    dontBuild = true;
-	    installPhase = ''
-	      mkdir $out $leanc_src
-	      mv bin/ include/ share/ $out/
-	      mv leanc.sh $out/bin/leanc
-	      mv leanc/Leanc.lean $leanc_src/
-	      substituteInPlace $out/bin/leanc --replace '$root' "$out" --replace " sed " " ${gnused}/bin/sed "
-	      substituteInPlace $out/bin/leanmake --replace "make" "${gnumake}/bin/make"
-	      substituteInPlace $out/share/lean/lean.mk --replace "/usr/bin/env bash" "${bash}/bin/bash"
-	    '';
-	  };
-	  leancpp = buildCMake {
-	    name = "leancpp";
-	    src = src + "/src";
-	    buildFlags = [ "leancpp" "leanrt" "leanrt_initial-exec" "leanshell" "leanmain" ];
-	    installPhase = ''
-	      mkdir -p $out
-	      mv lib/ $out/
-	      mv runtime/libleanrt_initial-exec.a $out/lib
-	    '';
-	  };
-	  stage0 = args.stage0 or (buildCMake {
-	    name = "lean-stage0";
-	    realSrc = src + "/stage0/src";
-	    debug = stage0debug;
-	    cmakeFlags = [ "-DSTAGE=0" ];
-	    extraCMakeFlags = [];
-	    preConfigure = ''
-	      ln -s ${src + "/stage0/stdlib"} ../stdlib
-	    '';
-	    installPhase = ''
-	      mkdir -p $out/bin $out/lib/lean
-	      mv bin/lean $out/bin/
-	      mv lib/lean/*.{so,dylib} $out/lib/lean
-	    '';
-	    meta.mainProgram = "lean";
-	  });
-	  stage = { stage, prevStage, self }:
-	    let
-	      desc = "stage${toString stage}";
-	      build = args: buildLeanPackage.override {
-	        lean = prevStage;
-	        leanc = lean-bin-tools-unwrapped;
-	        # use same stage for retrieving dependencies
-	        lean-leanDeps = stage0;
-	        lean-final = self;
-	      } ({
-	        src = src + "/src";
-	        roots = [ { mod = args.name; glob = "andSubmodules"; } ];
-	        fullSrc = src;
-	        srcPath = "$PWD/src:$PWD/src/lake";
-	        inherit debug;
-	        leanFlags = [ "-DwarningAsError=true" ];
-	      } // args);
-	      Init' = build { name = "Init"; deps = []; };
-	      Std' = build { name = "Std"; deps = [ Init' ]; };
-	      Lean' = build { name = "Lean"; deps = [ Std' ]; };
-	      attachSharedLib = sharedLib: pkg: pkg // {
-	        inherit sharedLib;
-	        mods = mapAttrs (_: m: m // { inherit sharedLib; propagatedLoadDynlibs = []; }) pkg.mods;
-	      };
-	    in (all: all // all.lean) rec {
-	      inherit (Lean) emacs-dev emacs-package vscode-dev vscode-package;
-	      Init = attachSharedLib leanshared Init';
-	      Std = attachSharedLib leanshared Std' // { allExternalDeps = [ Init ]; };
-	      Lean = attachSharedLib leanshared Lean' // { allExternalDeps = [ Std ]; };
-	      Lake = build {
-	        name = "Lake";
-	        sharedLibName = "Lake_shared";
-	        src = src + "/src/lake";
-	        deps = [ Init Lean ];
-	      };
-	      Lake-Main = build {
-	        name = "LakeMain";
-	        roots = [{ glob = "one"; mod = "LakeMain"; }];
-	        executableName = "lake";
-	        deps = [ Lake ];
-	        linkFlags = lib.optional stdenv.isLinux "-rdynamic";
-	        src = src + "/src/lake";
-	      };
-	      stdlib = [ Init Std Lean Lake ];
-	      modDepsFiles = symlinkJoin { name = "modDepsFiles"; paths = map (l: l.modDepsFile) (stdlib ++ [ Leanc ]); };
-	      depRoots = symlinkJoin { name = "depRoots"; paths = map (l: l.depRoots) stdlib; };
-	      iTree = symlinkJoin { name = "ileans"; paths = map (l: l.iTree) stdlib; };
-	      Leanc = build { name = "Leanc"; src = lean-bin-tools-unwrapped.leanc_src; deps = stdlib; roots = [ "Leanc" ]; };
-	      stdlibLinkFlags = "${lib.concatMapStringsSep " " (l: "-L${l.staticLib}") stdlib} -L${leancpp}/lib/lean";
-	      libInit_shared = runCommand "libInit_shared" { buildInputs = [ stdenv.cc ]; libName = "libInit_shared${stdenv.hostPlatform.extensions.sharedLibrary}"; } ''
-	        mkdir $out
-	        touch empty.c
-	        ${stdenv.cc}/bin/cc -shared -o $out/$libName empty.c
-	      '';
-	      leanshared_1 = runCommand "leanshared_1" { buildInputs = [ stdenv.cc ]; libName = "leanshared_1${stdenv.hostPlatform.extensions.sharedLibrary}"; } ''
-	        mkdir $out
-	        touch empty.c
-	        ${stdenv.cc}/bin/cc -shared -o $out/$libName empty.c
-	      '';
-	      leanshared = runCommand "leanshared" { buildInputs = [ stdenv.cc ]; libName = "libleanshared${stdenv.hostPlatform.extensions.sharedLibrary}"; } ''
-	        mkdir $out
-	        LEAN_CC=${stdenv.cc}/bin/cc ${lean-bin-tools-unwrapped}/bin/leanc -shared ${lib.optionalString stdenv.isLinux "-Wl,-Bsymbolic"} \
-	          ${if stdenv.isDarwin
-	            then "-Wl,-force_load,${Init.staticLib}/libInit.a -Wl,-force_load,${Std.staticLib}/libStd.a -Wl,-force_load,${Lean.staticLib}/libLean.a -Wl,-force_load,${leancpp}/lib/lean/libleancpp.a ${leancpp}/lib/libleanrt_initial-exec.a ${leancpp}/lib/temp/libleanshell.a -lc++"
-	           else "-Wl,--whole-archive ${leancpp}/lib/temp/libleanshell.a -lInit -lStd -lLean -lleancpp ${leancpp}/lib/libleanrt_initial-exec.a -Wl,--no-whole-archive -lstdc++"} \
-	          -lm ${stdlibLinkFlags} \
-	          $(${llvmPackages.libllvm.dev}/bin/llvm-config --ldflags --libs) \
-	          -o $out/$libName
-	      '';
-	      mods = foldl' (mods: pkg: mods // pkg.mods) {} stdlib;
-	      print-paths = Lean.makePrintPathsFor [] mods;
-	      leanc = writeShellScriptBin "leanc" ''
-	        LEAN_CC=${stdenv.cc}/bin/cc ${Leanc.executable}/bin/leanc -I${lean-bin-tools-unwrapped}/include ${stdlibLinkFlags} -L${libInit_shared} -L${leanshared_1} -L${leanshared} -L${Lake.sharedLib} "$@"
-	      '';
-	      lean = runCommand "lean" { buildInputs = lib.optional stdenv.isDarwin darwin.cctools; } ''
-	        mkdir -p $out/bin
-	        ${leanc}/bin/leanc ${leancpp}/lib/temp/libleanmain.a ${if stdenv.isDarwin then "${leancpp}/lib/temp/libleanshell.a" else ""} ${libInit_shared}/* ${leanshared_1}/* ${leanshared}/* -o $out/bin/lean
-	      '';
-	      # derivation following the directory layout of the "basic" setup, mostly useful for running tests
-	      lean-all = stdenv.mkDerivation {
-	        name = "lean-${desc}";
-	        buildCommand = ''
-	          mkdir -p $out/bin $out/lib/lean
-	          ln -sf ${leancpp}/lib/lean/* ${lib.concatMapStringsSep " " (l: "${l.modRoot}/* ${l.staticLib}/*") (lib.reverseList stdlib)} ${libInit_shared}/* ${leanshared_1}/* ${leanshared}/* ${Lake.sharedLib}/* $out/lib/lean/
-	          # put everything in a single final derivation so `IO.appDir` references work
-	          cp ${lean}/bin/lean ${leanc}/bin/leanc ${Lake-Main.executable}/bin/lake $out/bin
-	          # NOTE: `lndir` will not override existing `bin/leanc`
-	          ${lndir}/bin/lndir -silent ${lean-bin-tools-unwrapped} $out
-	        '';
-	        meta.mainProgram = "lean";
-	      };
-	      cacheRoots = linkFarmFromDrvs "cacheRoots" ([
-	        stage0 lean leanc lean-all iTree modDepsFiles depRoots Leanc.src
-	      ] ++ map (lib: lib.oTree) stdlib);
-	      test = buildCMake {
-	        name = "lean-test-${desc}";
-	        realSrc = lib.sourceByRegex src [ "src.*" "tests.*" ];
-	        buildInputs = [ gmp libuv perl git cadical ];
-	        preConfigure = ''
-	          cd src
-	        '';
-	        extraCMakeFlags = [ "-DLLVM=OFF" ];
-	        postConfigure = ''
-	          patchShebangs ../../tests ../lake
-	          rm -r bin lib include share
-	          ln -sf ${lean-all}/* .
-	        '';
-	        buildPhase = ''
-	          ctest --output-junit test-results.xml --output-on-failure -E 'leancomptest_(doc_example|foreign)|leanlaketest_reverse-ffi' -j$NIX_BUILD_CORES
-	        '';
-	        installPhase = ''
-	          mkdir $out
-	          mv test-results.xml $out
-	        '';
-	      };
-	      update-stage0 =
-	        let cTree = symlinkJoin { name = "cs"; paths = map (lib: lib.cTree) (stdlib ++ [Lake-Main]); }; in
-	        writeShellScriptBin "update-stage0" ''
-	          CSRCS=${cTree} CP_C_PARAMS="--dereference --no-preserve=all" ${src + "/script/lib/update-stage0"}
-	        '';
-	      update-stage0-commit = writeShellScriptBin "update-stage0-commit" ''
-	        set -euo pipefail
-	        ${update-stage0}/bin/update-stage0
-	        git commit -m "chore: update stage0"
-	      '';
-	      link-ilean = writeShellScriptBin "link-ilean" ''
-	        dest=''${1:-src}
-	        rm -rf $dest/build/lib || true
-	        mkdir -p $dest/build/lib
-	        ln -s ${iTree}/* $dest/build/lib
-	      '';
-	      benchmarks =
-	        let
-	          entries = attrNames (readDir (src + "/tests/bench"));
-	          leanFiles = map (n: elemAt n 0) (filter (n: n != null) (map (match "(.*)\.lean") entries));
-	        in lib.genAttrs leanFiles (n: (buildLeanPackage {
-	          name = n;
-	          src = filterSource (e: _: baseNameOf e == "${n}.lean") (src + "/tests/bench");
-	        }).executable);
-	    };
-	  stage1 = stage { stage = 1; prevStage = stage0; self = stage1; };
-	  stage2 = stage { stage = 2; prevStage = stage1; self = stage2; };
-	  stage3 = stage { stage = 3; prevStage = stage2; self = stage3; };
-	};
+          postConfigure = ''
+            	      patchShebangs .
+            	    '';
+        } // args // {
+          src = args.realSrc or (sourceByRegex args.src [ "[a-z].*" "CMakeLists\.txt" ]);
+          cmakeFlags = (args.cmakeFlags or [ "-DSTAGE=1" "-DPREV_STAGE=./faux-prev-stage" "-DUSE_GITHASH=OFF" "-DCADICAL=${cadical}/bin/cadical" ]) ++ (args.extraCMakeFlags or extraCMakeFlags) ++ lib.optional (args.debug or debug) [ "-DCMAKE_BUILD_TYPE=Debug" ];
+          preConfigure = args.preConfigure or "" + ''
+            	      # ignore absence of submodule
+            	      sed -i 's!lake/Lake.lean!!' CMakeLists.txt
+            	    '';
+        });
+        lean-bin-tools-unwrapped = buildCMake {
+          name = "lean-bin-tools";
+          outputs = [ "out" "leanc_src" ];
+          realSrc = sourceByRegex (src + "/src") [ "CMakeLists\.txt" "[a-z].*" ".*\.in" "Leanc\.lean" ];
+          dontBuild = true;
+          installPhase = ''
+            	      mkdir $out $leanc_src
+            	      mv bin/ include/ share/ $out/
+            	      mv leanc.sh $out/bin/leanc
+            	      mv leanc/Leanc.lean $leanc_src/
+            	      substituteInPlace $out/bin/leanc --replace '$root' "$out" --replace " sed " " ${gnused}/bin/sed "
+            	      substituteInPlace $out/bin/leanmake --replace "make" "${gnumake}/bin/make"
+            	      substituteInPlace $out/share/lean/lean.mk --replace "/usr/bin/env bash" "${bash}/bin/bash"
+            	    '';
+        };
+        leancpp = buildCMake {
+          name = "leancpp";
+          src = src + "/src";
+          buildFlags = [ "leancpp" "leanrt" "leanrt_initial-exec" "leanshell" "leanmain" ];
+          installPhase = ''
+            	      mkdir -p $out
+            	      mv lib/ $out/
+            	      mv runtime/libleanrt_initial-exec.a $out/lib
+            	    '';
+        };
+        stage0 = args.stage0 or (buildCMake {
+          name = "lean-stage0";
+          realSrc = src + "/stage0/src";
+          debug = stage0debug;
+          cmakeFlags = [ "-DSTAGE=0" ];
+          extraCMakeFlags = [ ];
+          preConfigure = ''
+            	      ln -s ${src + "/stage0/stdlib"} ../stdlib
+            	    '';
+          installPhase = ''
+            	      mkdir -p $out/bin $out/lib/lean
+            	      mv bin/lean $out/bin/
+            	      mv lib/lean/*.{so,dylib} $out/lib/lean
+            	    '';
+          meta.mainProgram = "lean";
+        });
+        stage = { stage, prevStage, self }:
+          let
+            desc = "stage${toString stage}";
+            build = args: buildLeanPackage.override
+              {
+                lean = prevStage;
+                leanc = lean-bin-tools-unwrapped;
+                # use same stage for retrieving dependencies
+                lean-leanDeps = stage0;
+                lean-final = self;
+              }
+              ({
+                src = src + "/src";
+                roots = [{ mod = args.name; glob = "andSubmodules"; }];
+                fullSrc = src;
+                srcPath = "$PWD/src:$PWD/src/lake";
+                inherit debug;
+                leanFlags = [ "-DwarningAsError=true" ];
+              } // args);
+            Init' = build { name = "Init"; deps = [ ]; };
+            Std' = build { name = "Std"; deps = [ Init' ]; };
+            Lean' = build { name = "Lean"; deps = [ Std' ]; };
+            attachSharedLib = sharedLib: pkg: pkg // {
+              inherit sharedLib;
+              mods = mapAttrs (_: m: m // { inherit sharedLib; propagatedLoadDynlibs = [ ]; }) pkg.mods;
+            };
+          in
+          (all: all // all.lean) rec {
+            inherit (Lean) emacs-dev emacs-package vscode-dev vscode-package;
+            Init = attachSharedLib leanshared Init';
+            Std = attachSharedLib leanshared Std' // { allExternalDeps = [ Init ]; };
+            Lean = attachSharedLib leanshared Lean' // { allExternalDeps = [ Std ]; };
+            Lake = build {
+              name = "Lake";
+              sharedLibName = "Lake_shared";
+              src = src + "/src/lake";
+              deps = [ Init Lean ];
+            };
+            Lake-Main = build {
+              name = "LakeMain";
+              roots = [{ glob = "one"; mod = "LakeMain"; }];
+              executableName = "lake";
+              deps = [ Lake ];
+              linkFlags = lib.optional stdenv.isLinux "-rdynamic";
+              src = src + "/src/lake";
+            };
+            stdlib = [ Init Std Lean Lake ];
+            modDepsFiles = symlinkJoin { name = "modDepsFiles"; paths = map (l: l.modDepsFile) (stdlib ++ [ Leanc ]); };
+            depRoots = symlinkJoin { name = "depRoots"; paths = map (l: l.depRoots) stdlib; };
+            iTree = symlinkJoin { name = "ileans"; paths = map (l: l.iTree) stdlib; };
+            Leanc = build { name = "Leanc"; src = lean-bin-tools-unwrapped.leanc_src; deps = stdlib; roots = [ "Leanc" ]; };
+            stdlibLinkFlags = "${lib.concatMapStringsSep " " (l: "-L${l.staticLib}") stdlib} -L${leancpp}/lib/lean";
+            libInit_shared = runCommand "libInit_shared" { buildInputs = [ stdenv.cc ]; libName = "libInit_shared${stdenv.hostPlatform.extensions.sharedLibrary}"; } ''
+              	        mkdir $out
+              	        touch empty.c
+              	        ${stdenv.cc}/bin/cc -shared -o $out/$libName empty.c
+              	      '';
+            leanshared_1 = runCommand "leanshared_1" { buildInputs = [ stdenv.cc ]; libName = "leanshared_1${stdenv.hostPlatform.extensions.sharedLibrary}"; } ''
+              	        mkdir $out
+              	        touch empty.c
+              	        ${stdenv.cc}/bin/cc -shared -o $out/$libName empty.c
+              	      '';
+            leanshared = runCommand "leanshared" { buildInputs = [ stdenv.cc ]; libName = "libleanshared${stdenv.hostPlatform.extensions.sharedLibrary}"; } ''
+              	        mkdir $out
+              	        LEAN_CC=${stdenv.cc}/bin/cc ${lean-bin-tools-unwrapped}/bin/leanc -shared ${lib.optionalString stdenv.isLinux "-Wl,-Bsymbolic"} \
+              	          ${if stdenv.isDarwin
+              	            then "-Wl,-force_load,${Init.staticLib}/libInit.a -Wl,-force_load,${Std.staticLib}/libStd.a -Wl,-force_load,${Lean.staticLib}/libLean.a -Wl,-force_load,${leancpp}/lib/lean/libleancpp.a ${leancpp}/lib/libleanrt_initial-exec.a ${leancpp}/lib/temp/libleanshell.a -lc++"
+              	           else "-Wl,--whole-archive ${leancpp}/lib/temp/libleanshell.a -lInit -lStd -lLean -lleancpp ${leancpp}/lib/libleanrt_initial-exec.a -Wl,--no-whole-archive -lstdc++"} \
+              	          -lm ${stdlibLinkFlags} \
+              	          $(${llvmPackages.libllvm.dev}/bin/llvm-config --ldflags --libs) \
+              	          -o $out/$libName
+              	      '';
+            mods = foldl' (mods: pkg: mods // pkg.mods) { } stdlib;
+            print-paths = Lean.makePrintPathsFor [ ] mods;
+            leanc = writeShellScriptBin "leanc" ''
+              	        LEAN_CC=${stdenv.cc}/bin/cc ${Leanc.executable}/bin/leanc -I${lean-bin-tools-unwrapped}/include ${stdlibLinkFlags} -L${libInit_shared} -L${leanshared_1} -L${leanshared} -L${Lake.sharedLib} "$@"
+              	      '';
+            lean = runCommand "lean" { buildInputs = lib.optional stdenv.isDarwin darwin.cctools; } ''
+              	        mkdir -p $out/bin
+              	        ${leanc}/bin/leanc ${leancpp}/lib/temp/libleanmain.a ${if stdenv.isDarwin then "${leancpp}/lib/temp/libleanshell.a" else ""} ${libInit_shared}/* ${leanshared_1}/* ${leanshared}/* -o $out/bin/lean
+              	      '';
+            # derivation following the directory layout of the "basic" setup, mostly useful for running tests
+            lean-all = stdenv.mkDerivation {
+              name = "lean-${desc}";
+              buildCommand = ''
+                	          mkdir -p $out/bin $out/lib/lean
+                	          ln -sf ${leancpp}/lib/lean/* ${lib.concatMapStringsSep " " (l: "${l.modRoot}/* ${l.staticLib}/*") (lib.reverseList stdlib)} ${libInit_shared}/* ${leanshared_1}/* ${leanshared}/* ${Lake.sharedLib}/* $out/lib/lean/
+                	          # put everything in a single final derivation so `IO.appDir` references work
+                	          cp ${lean}/bin/lean ${leanc}/bin/leanc ${Lake-Main.executable}/bin/lake $out/bin
+                	          # NOTE: `lndir` will not override existing `bin/leanc`
+                	          ${lndir}/bin/lndir -silent ${lean-bin-tools-unwrapped} $out
+                	        '';
+              meta.mainProgram = "lean";
+            };
+            cacheRoots = linkFarmFromDrvs "cacheRoots" ([
+              stage0
+              lean
+              leanc
+              lean-all
+              iTree
+              modDepsFiles
+              depRoots
+              Leanc.src
+            ] ++ map (lib: lib.oTree) stdlib);
+            test = buildCMake {
+              name = "lean-test-${desc}";
+              realSrc = lib.sourceByRegex src [ "src.*" "tests.*" ];
+              buildInputs = [ gmp libuv perl git cadical ];
+              preConfigure = ''
+                	          cd src
+                	        '';
+              extraCMakeFlags = [ "-DLLVM=OFF" ];
+              postConfigure = ''
+                	          patchShebangs ../../tests ../lake
+                	          rm -r bin lib include share
+                	          ln -sf ${lean-all}/* .
+                	        '';
+              buildPhase = ''
+                	          ctest --output-junit test-results.xml --output-on-failure -E 'leancomptest_(doc_example|foreign)|leanlaketest_reverse-ffi' -j$NIX_BUILD_CORES
+                	        '';
+              installPhase = ''
+                	          mkdir $out
+                	          mv test-results.xml $out
+                	        '';
+            };
+            update-stage0 =
+              let cTree = symlinkJoin { name = "cs"; paths = map (lib: lib.cTree) (stdlib ++ [ Lake-Main ]); }; in
+              writeShellScriptBin "update-stage0" ''
+                	          CSRCS=${cTree} CP_C_PARAMS="--dereference --no-preserve=all" ${src + "/script/lib/update-stage0"}
+                	        '';
+            update-stage0-commit = writeShellScriptBin "update-stage0-commit" ''
+              	        set -euo pipefail
+              	        ${update-stage0}/bin/update-stage0
+              	        git commit -m "chore: update stage0"
+              	      '';
+            link-ilean = writeShellScriptBin "link-ilean" ''
+              	        dest=''${1:-src}
+              	        rm -rf $dest/build/lib || true
+              	        mkdir -p $dest/build/lib
+              	        ln -s ${iTree}/* $dest/build/lib
+              	      '';
+            benchmarks =
+              let
+                entries = attrNames (readDir (src + "/tests/bench"));
+                leanFiles = map (n: elemAt n 0) (filter (n: n != null) (map (match "(.*)\.lean") entries));
+              in
+              lib.genAttrs leanFiles (n: (buildLeanPackage {
+                name = n;
+                src = filterSource (e: _: baseNameOf e == "${n}.lean") (src + "/tests/bench");
+              }).executable);
+          };
+        stage1 = stage { stage = 1; prevStage = stage0; self = stage1; };
+        stage2 = stage { stage = 2; prevStage = stage1; self = stage2; };
+        stage3 = stage { stage = 3; prevStage = stage2; self = stage3; };
+      };
 }

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,6 +1,6 @@
 let
   manifests = import ./manifests;
-  readSrc = { src, bootstrap } : final: prev: prev // rec {
+  readSrc = { src, bootstrap }: final: prev: prev // rec {
     lean = (prev.callPackage ./lib/packages.nix { inherit src bootstrap; }) // {
       lake = lean.Lake-Main.executable;
     };
@@ -15,12 +15,15 @@ let
     inherit bootstrap;
   };
   tags = builtins.mapAttrs (tag: manifest: readRev { inherit (manifest) rev bootstrap; }) manifests;
-  readToolchain = toolchain : builtins.addErrorContext "Only leanprover/lean4:{tag} toolchains are supported" (let
-    matches = builtins.match "^[[:space:]]*leanprover/lean4:([a-zA-Z0-9\\-\\.]+)[[:space:]]*$" toolchain;
-    tag = builtins.head matches;
-  in
-    builtins.getAttr tag tags);
-  readToolchainFile = toolchainFile : readToolchain (builtins.readFile toolchainFile);
-in {
+  readToolchain = toolchain: builtins.addErrorContext "Only leanprover/lean4:{tag} toolchains are supported" (
+    let
+      matches = builtins.match "^[[:space:]]*leanprover/lean4:([a-zA-Z0-9\\-\\.]+)[[:space:]]*$" toolchain;
+      tag = builtins.head matches;
+    in
+    builtins.getAttr tag tags
+  );
+  readToolchainFile = toolchainFile: readToolchain (builtins.readFile toolchainFile);
+in
+{
   inherit readSrc readFromGit readRev tags readToolchain readToolchainFile;
 }

--- a/templates/dependency/flake.nix
+++ b/templates/dependency/flake.nix
@@ -4,42 +4,29 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
     flake-parts.url = "github:hercules-ci/flake-parts";
+    systems.url = "github:nix-systems/default";
     lean4-nix.url = "github:lenianiva/lean4-nix";
   };
 
-  outputs =
-    inputs @ { self
-    , nixpkgs
-    , flake-parts
-    , lean4-nix
-    , ...
-    }: flake-parts.lib.mkFlake { inherit inputs; } {
-      flake = { };
-      systems = [
-        "x86_64-linux"
-        "x86_64-darwin"
-        "aarch64-linux"
-        "aarch64-darwin"
-      ];
-      perSystem = { system, pkgs, ... }:
-        let
-          pkgs = import nixpkgs {
-            inherit system;
-            overlays = [ (lean4-nix.readToolchainFile ./lean-toolchain) ];
-          };
-          project = (lean4-nix.lake { inherit pkgs; }).mkPackage {
-            src = ./.;
-            roots = [ "Example" ];
-          };
-        in
-        rec {
-          packages = {
-            inherit (project) executable;
-            default = project.executable;
-          };
-          devShells.default = pkgs.mkShell {
-            buildInputs = [ pkgs.lean.lean-all pkgs.lean.lean ];
-          };
-        };
+  outputs = inputs @ { nixpkgs, flake-parts, systems, lean4-nix, ... }: flake-parts.lib.mkFlake { inherit inputs; } {
+    systems = import systems;
+
+    perSystem = { pkgs, system, ... }: {
+      _module.args.pkgs = import nixpkgs {
+        inherit system;
+        overlays = [ (lean4-nix.readToolchainFile ./lean-toolchain) ];
+      };
+
+      devShells.default = pkgs.mkShell {
+        packages = with pkgs.lean; [ lean lean-all ];
+      };
+
+      formatter = pkgs.nixpkgs-fmt;
+
+      packages.default = ((lean4-nix.lake { inherit pkgs; }).mkPackage {
+        src = ./.;
+        roots = [ "Example" ];
+      }).executable;
     };
+  };
 }

--- a/templates/dependency/flake.nix
+++ b/templates/dependency/flake.nix
@@ -7,38 +7,39 @@
     lean4-nix.url = "github:lenianiva/lean4-nix";
   };
 
-  outputs = inputs @ {
-    self,
-    nixpkgs,
-    flake-parts,
-    lean4-nix,
-    ...
-  } : flake-parts.lib.mkFlake { inherit inputs; } {
-    flake = {
+  outputs =
+    inputs @ { self
+    , nixpkgs
+    , flake-parts
+    , lean4-nix
+    , ...
+    }: flake-parts.lib.mkFlake { inherit inputs; } {
+      flake = { };
+      systems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      perSystem = { system, pkgs, ... }:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ (lean4-nix.readToolchainFile ./lean-toolchain) ];
+          };
+          project = (lean4-nix.lake { inherit pkgs; }).mkPackage {
+            src = ./.;
+            roots = [ "Example" ];
+          };
+        in
+        rec {
+          packages = {
+            inherit (project) executable;
+            default = project.executable;
+          };
+          devShells.default = pkgs.mkShell {
+            buildInputs = [ pkgs.lean.lean-all pkgs.lean.lean ];
+          };
+        };
     };
-    systems = [
-      "x86_64-linux"
-      "x86_64-darwin"
-      "aarch64-linux"
-      "aarch64-darwin"
-    ];
-    perSystem = { system, pkgs, ... }: let
-      pkgs = import nixpkgs {
-        inherit system;
-        overlays = [ (lean4-nix.readToolchainFile ./lean-toolchain) ];
-      };
-      project = (lean4-nix.lake { inherit pkgs; }).mkPackage {
-        src = ./.;
-        roots = [ "Example" ];
-      };
-    in rec {
-      packages = {
-        inherit (project) executable;
-        default = project.executable;
-      };
-      devShells.default = pkgs.mkShell {
-        buildInputs = [ pkgs.lean.lean-all pkgs.lean.lean ];
-      };
-    };
-  };
 }

--- a/templates/minimal/flake.nix
+++ b/templates/minimal/flake.nix
@@ -7,39 +7,40 @@
     lean4-nix.url = "github:lenianiva/lean4-nix";
   };
 
-  outputs = inputs @ {
-    self,
-    nixpkgs,
-    flake-parts,
-    lean4-nix,
-    ...
-  } : flake-parts.lib.mkFlake { inherit inputs; } {
-    flake = {
+  outputs =
+    inputs @ { self
+    , nixpkgs
+    , flake-parts
+    , lean4-nix
+    , ...
+    }: flake-parts.lib.mkFlake { inherit inputs; } {
+      flake = { };
+      systems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      perSystem = { system, pkgs, ... }:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ (lean4-nix.readToolchainFile ./lean-toolchain) ];
+          };
+          project = pkgs.lean.buildLeanPackage {
+            name = "Example";
+            roots = [ "Main" ];
+            src = pkgs.lib.cleanSource ./.;
+          };
+        in
+        rec {
+          packages = {
+            inherit (project) executable;
+            default = project.executable;
+          };
+          devShells.default = pkgs.mkShell {
+            buildInputs = [ pkgs.lean.lean-all pkgs.lean.lean ];
+          };
+        };
     };
-    systems = [
-      "x86_64-linux"
-      "x86_64-darwin"
-      "aarch64-linux"
-      "aarch64-darwin"
-    ];
-    perSystem = { system, pkgs, ... }: let
-      pkgs = import nixpkgs {
-        inherit system;
-        overlays = [ (lean4-nix.readToolchainFile ./lean-toolchain) ];
-      };
-      project = pkgs.lean.buildLeanPackage {
-        name = "Example";
-        roots = [ "Main" ];
-        src = pkgs.lib.cleanSource ./.;
-      };
-    in rec {
-      packages = {
-        inherit (project) executable;
-        default = project.executable;
-      };
-      devShells.default = pkgs.mkShell {
-        buildInputs = [ pkgs.lean.lean-all pkgs.lean.lean ];
-      };
-    };
-  };
 }

--- a/templates/minimal/flake.nix
+++ b/templates/minimal/flake.nix
@@ -4,43 +4,30 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
     flake-parts.url = "github:hercules-ci/flake-parts";
+    systems.url = "github:nix-systems/default";
     lean4-nix.url = "github:lenianiva/lean4-nix";
   };
 
-  outputs =
-    inputs @ { self
-    , nixpkgs
-    , flake-parts
-    , lean4-nix
-    , ...
-    }: flake-parts.lib.mkFlake { inherit inputs; } {
-      flake = { };
-      systems = [
-        "x86_64-linux"
-        "x86_64-darwin"
-        "aarch64-linux"
-        "aarch64-darwin"
-      ];
-      perSystem = { system, pkgs, ... }:
-        let
-          pkgs = import nixpkgs {
-            inherit system;
-            overlays = [ (lean4-nix.readToolchainFile ./lean-toolchain) ];
-          };
-          project = pkgs.lean.buildLeanPackage {
-            name = "Example";
-            roots = [ "Main" ];
-            src = pkgs.lib.cleanSource ./.;
-          };
-        in
-        rec {
-          packages = {
-            inherit (project) executable;
-            default = project.executable;
-          };
-          devShells.default = pkgs.mkShell {
-            buildInputs = [ pkgs.lean.lean-all pkgs.lean.lean ];
-          };
-        };
+  outputs = inputs @ { nixpkgs, flake-parts, systems, lean4-nix, ... }: flake-parts.lib.mkFlake { inherit inputs; } {
+    systems = import systems;
+
+    perSystem = { pkgs, system, ... }: {
+      _module.args.pkgs = import nixpkgs {
+        inherit system;
+        overlays = [ (lean4-nix.readToolchainFile ./lean-toolchain) ];
+      };
+
+      devShells.default = pkgs.mkShell {
+        packages = with pkgs.lean; [ lean lean-all ];
+      };
+
+      formatter = pkgs.nixpkgs-fmt;
+
+      packages.default = (pkgs.lean.buildLeanPackage {
+        name = "Example";
+        roots = [ "Main" ];
+        src = pkgs.lib.cleanSource ./.;
+      }).executable;
     };
+  };
 }


### PR DESCRIPTION
- added `nixpkgs-fmt` and reformatted the codebase with it
- added `systems` to inputs, making outputs overridable
- instead of using expensive `with pkgs;`, packages used in `lib/packages.nix` should refer to the ones listed in the argument section (provided with `callPackage`)

I'll take a look into https://github.com/lenianiva/lean4-nix/issues/5#issuecomment-2460718642 in a bit