### PR TITLE
Support non-string `manifest.version`

### DIFF
--- a/lake.nix
+++ b/lake.nix
@@ -7,7 +7,7 @@
   importLakeManifest = manifestFile: let
     manifest = pkgs.lib.importJSON manifestFile;
   in
-    pkgs.lib.warnIf (manifest.version != "1.1.0") ("Unknown version: " + manifest.version) manifest;
+    pkgs.lib.warnIf (manifest.version != "1.1.0") ("Unknown version: " + builtins.toString manifest.version) manifest;
   depToPackage = dep: let
     src = pkgs.lib.cleanSource (builtins.fetchGit {
       inherit (dep) url rev;


### PR DESCRIPTION
This fixes a crash on the [`lake-manifest.json` of lean4-cli](https://github.com/leanprover/lean4-cli/blob/main/lake-manifest.json).