### PR TITLE
chore: Change `nixpkgs` to unstable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Lean 4 Nix
 
+[![built with garnix](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fgarnix.io%2Fapi%2Fbadges%2Flenianiva%2Flean4-nix)](https://garnix.io/repo/lenianiva/lean4-nix)
+
 Nix flake build for Lean 4.
 
 Features:
@@ -23,6 +25,10 @@ fetch dependencies automatically.
 ``` sh
 nix flake new --template github:lenianiva/lean4-nix#dependency ./dependency
 ```
+
+## Caching
+
+This project has CI by Garnix and uses `cache.garnix.io`.
 
 ## Flake outputs
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ nix flake new --template github:lenianiva/lean4-nix#dependency ./dependency
 
 ## Caching
 
-This project has CI by Garnix and uses `cache.garnix.io`.
+This project has CI by Garnix and uses [`cache.garnix.io`](https://garnix.io/docs/caching) for binary caching.
 
 ## Flake outputs
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728500571,
-        "narHash": "sha256-dOymOQ3AfNI4Z337yEwHGohrVQb4yPODCW9MDUyAc4w=",
+        "lastModified": 1743095683,
+        "narHash": "sha256-gWd4urRoLRe8GLVC/3rYRae1h+xfQzt09xOfb0PaHSk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d51c28603def282a24fa034bcb007e2bcb5b5dd0",
+        "rev": "5e5402ecbcb27af32284d4a62553c019a3a49ea6",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.05",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Lean 4 Nix Flake";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
   };
 

--- a/templates/dependency/flake.nix
+++ b/templates/dependency/flake.nix
@@ -4,7 +4,10 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
     flake-parts.url = "github:hercules-ci/flake-parts";
-    lean4-nix.url = "github:lenianiva/lean4-nix";
+    lean4-nix = {
+      url = "github:lenianiva/lean4-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = inputs @ {

--- a/templates/minimal/flake.nix
+++ b/templates/minimal/flake.nix
@@ -4,7 +4,10 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
     flake-parts.url = "github:hercules-ci/flake-parts";
-    lean4-nix.url = "github:lenianiva/lean4-nix";
+    lean4-nix = {
+      url = "github:lenianiva/lean4-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = inputs @ {


### PR DESCRIPTION
- doc: Add Garnix build badges
- doc: Add mentions about caching (so people don't just fork this to cache the build)