### PR TITLE
feat: Support `staticLibDeps` in `mkPackage`

### DIFF
--- a/lake.nix
+++ b/lake.nix
@@ -27,6 +27,8 @@
     roots ? null,
     # Default dependencies
     deps ? with pkgs.lean; [Init Std Lean],
+    # Static library dependencies
+    staticLibDeps ? null,
   }: let
     manifest = importLakeManifest manifestFile;
     # Build all dependencies using `buildLeanPackage`
@@ -40,7 +42,10 @@
         then [(capitalize manifest.name)]
         else roots;
       deps = deps ++ manifestDeps;
-
+      staticLibDeps =
+        if builtins.isNull staticLibDeps
+        then []
+        else staticLibDeps;
       # Fixes some symbol not found errors
       groupStaticLibs = true;
     };

--- a/lake.nix
+++ b/lake.nix
@@ -28,7 +28,7 @@
     # Default dependencies
     deps ? with pkgs.lean; [Init Std Lean],
     # Static library dependencies
-    staticLibDeps ? null,
+    staticLibDeps ? [],
   }: let
     manifest = importLakeManifest manifestFile;
     # Build all dependencies using `buildLeanPackage`
@@ -36,16 +36,12 @@
   in
     pkgs.lean.buildLeanPackage {
       inherit (manifest) name;
-      inherit src;
+      inherit src staticLibDeps;
       roots =
         if builtins.isNull roots
         then [(capitalize manifest.name)]
         else roots;
       deps = deps ++ manifestDeps;
-      staticLibDeps =
-        if builtins.isNull staticLibDeps
-        then []
-        else staticLibDeps;
       # Fixes some symbol not found errors
       groupStaticLibs = true;
     };


### PR DESCRIPTION
This enables users of `mkPackage` to directly include static libraries, rather than having to use `mkPackage` for Lean dependencies and then including it in a separate `buildLeanPackage` with static libs.

Usage example: https://github.com/argumentcomputer/Blake3.lean/blob/main/flake.nix#L45-L51