### PR TITLE
doc: Add documentation about re-using bootstrapping functions and devShell

### DIFF
--- a/templates/dependency/flake.nix
+++ b/templates/dependency/flake.nix
@@ -42,7 +42,7 @@
           .executable;
 
         devShells.default = pkgs.mkShell {
-          packages = with pkgs.lean; [lean lean-all];
+          packages = with pkgs.lean; [lean-all];
         };
       };
     };

--- a/templates/minimal/flake.nix
+++ b/templates/minimal/flake.nix
@@ -43,7 +43,7 @@
           .executable;
 
         devShells.default = pkgs.mkShell {
-          packages = with pkgs.lean; [lean lean-all];
+          packages = with pkgs.lean; [lean-all];
         };
       };
     };


### PR DESCRIPTION
- fix: Only use `lean-all` in devShell defaults. (Resolves #54)
- doc: Add instructions for re-using bootstrapping functions (Resolves #50)