### PR TITLE
refactor: Build `lean` directly in packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,15 @@ This project has CI by Garnix and uses
 
 ### Packages
 
-The flake's `packages` output contains the Lean and lake executables. The
-version corresponds to the latest version in the `manifests/` directory.
+The flake's `packages.${system}.lean` output contains the Lean and lake
+executables. The version corresponds to the latest version in the `manifests/`
+directory.
 
 - `lean-all`: `lean` and `lake`
 - `lean`/`leanc`/`lake`: Executables
 - `leanshared`: Shared library of Lean
 - `cacheRoots`: Cached derivations to enable binary caching.
+- `buildLeanPackage`: See below
 
 ### Overlay
 

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
         };
 
         packages = {
-          inherit (pkgs.lean) cacheRoots leanshared lean leanc lean-all lake;
+          inherit (pkgs) lean;
         };
 
         checks = import ./checks.nix {inherit pkgs;};


### PR DESCRIPTION
This way we can use the flake output directly to build lean packages, pinned to the `nixpkgs` version specified in the flake itself.