### PR TITLE
build: Add back cacheRoots

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,7 @@
 
         packages = {
           inherit (pkgs) lean;
+          inherit (pkgs.lean) cacheRoots;
         };
 
         checks = import ./checks.nix {inherit pkgs;};


### PR DESCRIPTION
In #67 we consolidates all outputs into `lean`, and this caused CI cache misses.