### PR TITLE
fix: Dynamically-built executables from binary toolchains

### DIFF
--- a/checks.nix
+++ b/checks.nix
@@ -86,4 +86,5 @@ in
   // (generate-lake-tests {
     lake = lake2nix;
     lean = pkgs.lean;
+    prefix = "src-";
   })

--- a/lib/toolchain.nix
+++ b/lib/toolchain.nix
@@ -65,7 +65,7 @@
         rm -r include/clang
         ln -s ${clang}/resource-root/include include/clang
 
-        # Remove
+        # Remove shipped clang libraries
         rm -r lib/clang
 
         mv ./* $out/


### PR DESCRIPTION
This fixes a build error on NixOS, which Garnix and Arch Linux both cannot replicate.

~~We may need to use this fix on earlier (<4.22.0) versions `buildLeanPackage` if it occurs for these versions.~~