### PR TITLE
refactor: Remove mentions of `pkgs.system`

### DIFF
--- a/lib/toolchain.nix
+++ b/lib/toolchain.nix
@@ -4,7 +4,6 @@
   pkgs,
   fetchurl,
   stdenv,
-  system,
   zstd,
   clang,
   lld,
@@ -14,7 +13,9 @@
   writeShellApplication,
   autoPatchelfHook,
   ...
-}: rec {
+}: let
+  inherit (stdenv.hostPlatform) system;
+in rec {
   toolchain-fetch = writeShellApplication {
     name = "toolchain-fetch";
     runtimeInputs = with pkgs; [jq git wget coreutils nix];

--- a/manifests/v4.22.0.nix
+++ b/manifests/v4.22.0.nix
@@ -94,7 +94,7 @@
               // {
                 name = lib.strings.sanitizeDerivationName args.name;
                 stdenv = bareStdenv;
-                inherit (stdenv) system;
+                inherit (stdenv.hostPlatform) system;
                 buildInputs = (args.buildInputs or []) ++ [coreutils];
                 builder = stdenv.shell;
                 args = [

--- a/manifests/v4.27.0.nix
+++ b/manifests/v4.27.0.nix
@@ -114,7 +114,7 @@
               // {
                 name = lib.strings.sanitizeDerivationName args.name;
                 stdenv = bareStdenv;
-                inherit (stdenv) system;
+                inherit (stdenv.hostPlatform) system;
                 buildInputs = (args.buildInputs or []) ++ [coreutils];
                 builder = stdenv.shell;
                 args = [


### PR DESCRIPTION
This removes the warning

```
evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'
```