### PR TITLE
fix: Increase RAM to 4GB in VM build

### DIFF
--- a/checks.nix
+++ b/checks.nix
@@ -110,6 +110,7 @@
             ...
           }: {
             virtualisation.diskSize = 2048;
+            virtualisation.memorySize = 4096;
             networking = {hostName = "hakkero";};
             environment = {
               variables.EDITOR = "vim";


### PR DESCRIPTION
Fixes OOM errors in the `bin-minimal-exec-vm` and `src-minimal-exec-vm` checks, e.g. https://app.garnix.io/build/gN12rpe9