### PR TITLE
fix: Skip batteries-dependent checks on v4.31.0

### DIFF
--- a/checks.nix
+++ b/checks.nix
@@ -110,6 +110,7 @@
             ...
           }: {
             virtualisation.diskSize = 2048;
+            virtualisation.memorySize = 4096;
             networking = {hostName = "hakkero";};
             environment = {
               variables.EDITOR = "vim";

--- a/checks.nix
+++ b/checks.nix
@@ -4,6 +4,12 @@
   pkgs,
 }: let
   inherit (pkgs-bin) lib;
+  # batteries v4.31.0 cannot be built as a Lake dependency due to an upstream
+  # import cycle between its libraries, so the checks depending on it are
+  # skipped. See the note in manifests/v4.31.0.nix.
+  batteries-broken =
+    lib.hasSuffix "v4.31.0"
+    (lib.fileContents ./templates/minimal/lean-toolchain);
   generate-lake-tests = {
     prefix ? "",
     lean,
@@ -80,9 +86,7 @@
         '';
         installArtifacts = false;
       };
-  in
-    lib.mapAttrs' (name: value: lib.nameValuePair "${prefix}${name}" value)
-    rec {
+    lake-tests = rec {
       minimal-direct-lib = minimal-direct.sharedLib;
       minimal-direct-bin = minimal-direct.executable;
       minimal-manifest-bin = minimal-manifest;
@@ -126,8 +130,13 @@
           hakkero.succeed("example")
         '';
       });
-      inherit dependency-manifest incremental-lib incremental-test incremental-test-dep;
     };
+  in
+    lib.mapAttrs' (name: value: lib.nameValuePair "${prefix}${name}" value)
+    (lake-tests
+      // lib.optionalAttrs (!batteries-broken) {
+        inherit dependency-manifest incremental-lib incremental-test incremental-test-dep;
+      });
   lake2nix = pkgs.callPackage lib/lake.nix {};
 in
   {

--- a/manifests/v4.31.0.nix
+++ b/manifests/v4.31.0.nix
@@ -1,3 +1,12 @@
+# NOTE: batteries v4.31.0 has an import cycle between its `Batteries` and
+# `BatteriesRecycling` libraries, so building its `shared`/`static` facets
+# fails with "build cycle detected" and batteries cannot be used as a Lake
+# dependency on this toolchain (directly or transitively, e.g. via aesop).
+# The fix (https://github.com/leanprover-community/batteries/pull/1868) was
+# first released in batteries v4.32.0; no batteries release for the v4.31.0
+# toolchain contains it. The batteries-dependent checks are skipped for this
+# version in checks.nix.
+# See https://github.com/leanprover-community/batteries/issues/1832
 {
   tag = "v4.31.0";
   rev = "68218e876d2a38b1985b8590fff244a83c321783";


### PR DESCRIPTION
batteries v4.31.0 has an import cycle between its Batteries and BatteriesRecycling libraries (https://github.com/leanprover-community/batteries/issues/1832), so building its shared/static facets fails with "build cycle detected" and it cannot be used as a Lake dependency on this toolchain. The fix (leanprover-community/batteries#1868) was first released in batteries v4.32.0; no release for the v4.31.0 toolchain contains it.

Skip the checks depending on batteries when the template toolchain is v4.31.0; they re-enable automatically on the next version bump.